### PR TITLE
feat: 사용자 피드백(건의사항) 기능 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/feedback/controller/admin/FeedbackAdminController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/controller/admin/FeedbackAdminController.java
@@ -1,0 +1,41 @@
+package com.example.cowmjucraft.domain.feedback.controller.admin;
+
+import com.example.cowmjucraft.domain.feedback.dto.request.FeedbackAdminUpdateRequestDto;
+import com.example.cowmjucraft.domain.feedback.dto.response.FeedbackAdminResponseDto;
+import com.example.cowmjucraft.domain.feedback.service.FeedbackService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/admin")
+public class FeedbackAdminController implements FeedbackAdminControllerDocs {
+
+    private final FeedbackService feedbackService;
+
+    @GetMapping("/feedback")
+    @Override
+    public List<FeedbackAdminResponseDto> getFeedbacks() {
+        return feedbackService.getFeedbacks();
+    }
+
+    @PutMapping("/feedback/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Override
+    public void updateFeedback(
+            @PathVariable Long id,
+            @Valid @RequestBody FeedbackAdminUpdateRequestDto request
+    ) {
+        feedbackService.updateFeedback(id, request);
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/controller/admin/FeedbackAdminControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/controller/admin/FeedbackAdminControllerDocs.java
@@ -1,0 +1,61 @@
+package com.example.cowmjucraft.domain.feedback.controller.admin;
+
+import com.example.cowmjucraft.domain.feedback.dto.request.FeedbackAdminUpdateRequestDto;
+import com.example.cowmjucraft.domain.feedback.dto.response.FeedbackAdminResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.Parameter;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+@Tag(name = "Feedback (Admin)", description = "건의사항 관리자 API")
+public interface FeedbackAdminControllerDocs {
+
+    @Operation(
+            summary = "건의사항 목록 조회",
+            description = "등록된 건의사항 목록을 최신순으로 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = FeedbackAdminResponseDto.class)))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
+    List<FeedbackAdminResponseDto> getFeedbacks();
+
+    @Operation(
+            summary = "건의사항 답변 및 상태 변경",
+            description = "관리자가 답변과 처리 상태를 업데이트합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 검증 실패"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "대상 없음")
+    })
+    void updateFeedback(
+            @Parameter(
+                    description = "피드백 ID",
+                    example = "1"
+            )
+            Long id,
+            @RequestBody(
+                    required = true,
+                    description = "답변 및 상태 변경 정보",
+                    content = @Content(schema = @Schema(implementation = FeedbackAdminUpdateRequestDto.class))
+            )
+            @Valid
+            FeedbackAdminUpdateRequestDto request
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/controller/client/FeedbackController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/controller/client/FeedbackController.java
@@ -1,0 +1,27 @@
+package com.example.cowmjucraft.domain.feedback.controller.client;
+
+import com.example.cowmjucraft.domain.feedback.dto.request.FeedbackRequestDto;
+import com.example.cowmjucraft.domain.feedback.service.FeedbackService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class FeedbackController implements FeedbackControllerDocs {
+
+    private final FeedbackService feedbackService;
+
+    @PostMapping("/feedback")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Override
+    public void createFeedback(@Valid @RequestBody FeedbackRequestDto request) {
+        feedbackService.createFeedback(request);
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/controller/client/FeedbackControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/controller/client/FeedbackControllerDocs.java
@@ -1,0 +1,34 @@
+package com.example.cowmjucraft.domain.feedback.controller.client;
+
+import com.example.cowmjucraft.domain.feedback.dto.request.FeedbackRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "Feedback (Public)", description = "건의사항 등록 API")
+public interface FeedbackControllerDocs {
+
+    @Operation(
+            summary = "건의사항 등록",
+            description = "사용자가 건의사항을 등록합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 검증 실패")
+    })
+    void createFeedback(
+            @RequestBody(
+                    required = true,
+                    description = "건의사항 등록 정보",
+                    content = @Content(schema = @Schema(implementation = FeedbackRequestDto.class))
+            )
+            @Valid
+            FeedbackRequestDto request
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/dto/request/FeedbackAdminUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/dto/request/FeedbackAdminUpdateRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.cowmjucraft.domain.feedback.dto.request;
+
+import com.example.cowmjucraft.domain.feedback.entity.FeedbackStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "피드백 관리자 답변/상태 변경 요청 DTO")
+public record FeedbackAdminUpdateRequestDto(
+
+        @Schema(
+                description = "답변 내용",
+                example = "좋은 의견 감사합니다. 다음 배포에 반영하겠습니다."
+        )
+        String answer,
+
+        @NotNull
+        @Schema(
+                description = "처리 상태",
+                example = "ANSWERED",
+                allowableValues = {"RECEIVED", "ANSWERED"}
+        )
+        FeedbackStatus status
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/dto/request/FeedbackRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/dto/request/FeedbackRequestDto.java
@@ -1,0 +1,23 @@
+package com.example.cowmjucraft.domain.feedback.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "피드백 등록 요청 DTO")
+public record FeedbackRequestDto(
+
+        @NotBlank
+        @Schema(
+                description = "제목",
+                example = "예약 화면 개선 요청"
+        )
+        String title,
+
+        @NotBlank
+        @Schema(
+                description = "건의 내용",
+                example = "예약 가능한 날짜를 달력으로 보여주면 좋겠습니다."
+        )
+        String content
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/dto/response/FeedbackAdminResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/dto/response/FeedbackAdminResponseDto.java
@@ -1,0 +1,49 @@
+package com.example.cowmjucraft.domain.feedback.dto.response;
+
+import com.example.cowmjucraft.domain.feedback.entity.Feedback;
+import com.example.cowmjucraft.domain.feedback.entity.FeedbackStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "피드백 관리자 응답 DTO")
+public record FeedbackAdminResponseDto(
+
+        @Schema(
+                description = "피드백 ID",
+                example = "1"
+        )
+        Long id,
+
+        @Schema(
+                description = "제목",
+                example = "예약 화면 개선 요청"
+        )
+        String title,
+
+        @Schema(
+                description = "건의 내용",
+                example = "예약 가능한 날짜를 달력으로 보여주면 좋겠습니다."
+        )
+        String content,
+
+        @Schema(
+                description = "답변 내용",
+                example = "좋은 의견 감사합니다. 다음 배포에 반영하겠습니다."
+        )
+        String answer,
+
+        @Schema(
+                description = "처리 상태",
+                example = "ANSWERED"
+        )
+        FeedbackStatus status
+) {
+    public static FeedbackAdminResponseDto from(Feedback feedback) {
+        return new FeedbackAdminResponseDto(
+                feedback.getId(),
+                feedback.getTitle(),
+                feedback.getContent(),
+                feedback.getAnswer(),
+                feedback.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/entity/Feedback.java
@@ -1,0 +1,50 @@
+package com.example.cowmjucraft.domain.feedback.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "feedbacks")
+public class Feedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FeedbackStatus status = FeedbackStatus.RECEIVED;
+
+    @Lob
+    @Column
+    private String answer;
+
+    public Feedback(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public void updateAnswer(String answer, FeedbackStatus status) {
+        this.answer = answer;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/entity/FeedbackStatus.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/entity/FeedbackStatus.java
@@ -1,0 +1,6 @@
+package com.example.cowmjucraft.domain.feedback.entity;
+
+public enum FeedbackStatus {
+    RECEIVED,
+    ANSWERED
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,10 @@
+package com.example.cowmjucraft.domain.feedback.repository;
+
+import com.example.cowmjucraft.domain.feedback.entity.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+    List<Feedback> findAllByOrderByIdDesc();
+}

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/service/FeedbackService.java
@@ -1,0 +1,54 @@
+package com.example.cowmjucraft.domain.feedback.service;
+
+import com.example.cowmjucraft.domain.feedback.dto.request.FeedbackAdminUpdateRequestDto;
+import com.example.cowmjucraft.domain.feedback.dto.request.FeedbackRequestDto;
+import com.example.cowmjucraft.domain.feedback.dto.response.FeedbackAdminResponseDto;
+import com.example.cowmjucraft.domain.feedback.entity.Feedback;
+import com.example.cowmjucraft.domain.feedback.repository.FeedbackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Service
+public class FeedbackService {
+
+    private final FeedbackRepository feedbackRepository;
+
+    @Transactional
+    public void createFeedback(FeedbackRequestDto request) {
+        FeedbackRequestDto safeRequest =
+                Objects.requireNonNull(request, "request must not be null");
+
+        Feedback feedback = new Feedback(
+                safeRequest.title(),
+                safeRequest.content()
+        );
+
+        feedbackRepository.save(feedback);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeedbackAdminResponseDto> getFeedbacks() {
+        return feedbackRepository.findAllByOrderByIdDesc()
+                .stream()
+                .map(FeedbackAdminResponseDto::from)
+                .toList();
+    }
+
+    @Transactional
+    public void updateFeedback(Long id, FeedbackAdminUpdateRequestDto request) {
+        FeedbackAdminUpdateRequestDto safeRequest =
+                Objects.requireNonNull(request, "request must not be null");
+
+        Feedback feedback = feedbackRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "feedback not found"));
+
+        feedback.updateAnswer(safeRequest.answer(), safeRequest.status());
+    }
+}


### PR DESCRIPTION
- 사용자는 피드백을 등록할 수 있고 관리자는 해당 피드백에 대해서 조회, 답변, 상태 변경을 수행할 수 있습니다.
- 관리자는 최신순 목록을 보고 ANSWERED/RECEIVED 상태로 변경할 수 있습니다.

사용자 등록: POST /api/feedback (204)
관리자 조회: GET /api/admin/feedback (200)
관리자 답변/상태 변경: PUT /api/admin/feedback/{id} (204)