### PR TITLE
feat: 관리자 미디어 presign 업로드 및 소개 콘텐츠 연동 구현

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/introduce/intro/controller/admin/IntroduceAdminControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/intro/controller/admin/IntroduceAdminControllerDocs.java
@@ -20,6 +20,7 @@ public interface IntroduceAdminControllerDocs {
             명지공방 소개 내용을 전체 교체합니다.
             - 요청으로 들어온 내용이 최종 상태가 됩니다.
             - 등록/수정을 PUT 하나로 처리합니다.
+            - 이미지는 Media API로 presign 발급 → S3 업로드 → activate 완료 후, 여기에는 mediaId만 연결합니다.
             """
     )
     @ApiResponses({

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/intro/controller/client/IntroduceControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/intro/controller/client/IntroduceControllerDocs.java
@@ -13,7 +13,7 @@ public interface IntroduceControllerDocs {
 
     @Operation(
             summary = "명지공방 소개 조회",
-            description = "명지공방 소개 내용을 조회합니다."
+            description = "명지공방 소개 내용을 조회합니다. 이미지가 필요하면 응답의 mediaId로 /api/media/{id}/url을 호출하세요."
     )
     @ApiResponses({
             @ApiResponse(

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/intro/dto/request/IntroduceAdminRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/intro/dto/request/IntroduceAdminRequestDto.java
@@ -2,6 +2,7 @@ package com.example.cowmjucraft.domain.introduce.intro.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 
 @Schema(description = "명지공방 소개 관리자 요청 DTO")
 public record IntroduceAdminRequestDto(
@@ -18,6 +19,14 @@ public record IntroduceAdminRequestDto(
                 description = "소개 본문",
                 example = "명지공방은 학생들이 함께 만드는 공방 서비스입니다."
         )
-        String content
+        String content,
+
+        @Positive
+        @Schema(description = "소개 로고 이미지 mediaId (없으면 null)", example = "1")
+        Long logoMediaId,
+
+        @Positive
+        @Schema(description = "소개 배너 이미지 mediaId (없으면 null)", example = "2")
+        Long bannerMediaId
 ) {
 }

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/intro/dto/response/IntroduceResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/intro/dto/response/IntroduceResponseDto.java
@@ -16,12 +16,20 @@ public record IntroduceResponseDto(
                 description = "소개 본문",
                 example = "명지공방은 학생들이 함께 만드는 공방 서비스입니다."
         )
-        String content
+        String content,
+
+        @Schema(description = "소개 로고 이미지 mediaId (필요 시 /api/media/{id}/url 호출)", example = "1")
+        Long logoMediaId,
+
+        @Schema(description = "소개 배너 이미지 mediaId (필요 시 /api/media/{id}/url 호출)", example = "2")
+        Long bannerMediaId
 ) {
     public static IntroduceResponseDto from(IntroduceContent content) {
         return new IntroduceResponseDto(
                 content.getTitle(),
-                content.getContent()
+                content.getContent(),
+                content.getLogoMediaId(),
+                content.getBannerMediaId()
         );
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/intro/entity/IntroduceContent.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/intro/entity/IntroduceContent.java
@@ -28,8 +28,16 @@ public class IntroduceContent {
     @Column(nullable = false)
     private String content;
 
-    public IntroduceContent(String title, String content) {
+    @Column
+    private Long logoMediaId;
+
+    @Column
+    private Long bannerMediaId;
+
+    public IntroduceContent(String title, String content, Long logoMediaId, Long bannerMediaId) {
         this.title = title;
         this.content = content;
+        this.logoMediaId = logoMediaId;
+        this.bannerMediaId = bannerMediaId;
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/intro/service/IntroduceContentService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/intro/service/IntroduceContentService.java
@@ -28,11 +28,16 @@ public class IntroduceContentService {
         IntroduceAdminRequestDto safeRequest =
                 Objects.requireNonNull(request, "request must not be null");
 
+        // TODO: replace 방식 대신 단일 row 업데이트로 개선해 이력/잠금 이슈를 줄일 수 있음.
         introduceContentRepository.deleteAllInBatch();
 
+        // TODO: mediaId 존재/ACTIVE/usageType 일치 검증을 도입해 잘못된 참조를 사전에 차단하는 방식 검토 필요.
+        // TODO: PENDING/DELETED 상태의 Media 정리를 위한 배치/비동기 정책을 Media 도메인에 추가 검토 필요.
         IntroduceContent content = new IntroduceContent(
                 safeRequest.title(),
-                safeRequest.content()
+                safeRequest.content(),
+                safeRequest.logoMediaId(),
+                safeRequest.bannerMediaId()
         );
 
         introduceContentRepository.save(content);


### PR DESCRIPTION
- S3 presigned URL 기반 미디어 업로드 도메인 추가
- Media 상태(PENDING/ACTIVE/DELETED) 관리
- 공개 미디어 조회 API 제공
- 소개 페이지에서 mediaId 기반 이미지 연동