### PR TITLE
refactor: media presign 흐름 정리 및 activate 제거

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/media/controller/admin/AdminMediaController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/media/controller/admin/AdminMediaController.java
@@ -27,16 +27,9 @@ public class AdminMediaController implements AdminMediaControllerDocs {
         return mediaService.presignUpload(request);
     }
 
-    @PostMapping("/{mediaId}/activate")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @Override
-    public void activate(@PathVariable Long mediaId) {
-        mediaService.activate(mediaId);
-    }
-
     @DeleteMapping("/{mediaId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Override
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long mediaId) {
         mediaService.delete(mediaId);
     }

--- a/src/main/java/com/example/cowmjucraft/domain/media/controller/admin/AdminMediaControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/media/controller/admin/AdminMediaControllerDocs.java
@@ -19,7 +19,7 @@ public interface AdminMediaControllerDocs {
 
     @Operation(
             summary = "업로드용 presign 발급",
-            description = "presign 발급 → S3에 직접 PUT 업로드 → 성공 후 activate 호출 흐름을 위한 첫 단계입니다."
+            description = "presign 발급 → S3에 직접 PUT 업로드 흐름을 위한 첫 단계입니다. presign은 Media 엔티티를 생성하지 않으며, 업로드 후 Media 생성 및 도메인 연결은 추후 도메인 API에서 처리합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "발급 성공", content = @Content(schema = @Schema(implementation = AdminMediaPresignResponseDto.class))),
@@ -28,19 +28,6 @@ public interface AdminMediaControllerDocs {
             @ApiResponse(responseCode = "403", description = "ADMIN 권한 아님")
     })
     AdminMediaPresignResponseDto presign(@Valid @RequestBody AdminMediaPresignRequestDto request);
-
-    @Operation(
-            summary = "미디어 활성화",
-            description = "도메인(소개/프로젝트) 저장 성공 후 mediaId를 기준으로 상태를 ACTIVE로 전환합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "활성화 완료"),
-            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
-            @ApiResponse(responseCode = "401", description = "인증 실패"),
-            @ApiResponse(responseCode = "403", description = "ADMIN 권한 아님"),
-            @ApiResponse(responseCode = "404", description = "대상 미디어 없음")
-    })
-    void activate(@PathVariable Long mediaId);
 
     @Operation(
             summary = "미디어 삭제",

--- a/src/main/java/com/example/cowmjucraft/domain/media/dto/response/AdminMediaPresignResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/media/dto/response/AdminMediaPresignResponseDto.java
@@ -1,13 +1,15 @@
 package com.example.cowmjucraft.domain.media.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record AdminMediaPresignResponseDto(
-        @io.swagger.v3.oas.annotations.media.Schema(description = "생성된 미디어 ID", example = "1")
-        Long mediaId,
-        @io.swagger.v3.oas.annotations.media.Schema(description = "S3 object key", example = "uploads/uuid-intro-banner.png")
+        @Schema(description = "S3 object key", example = "uploads/uuid-intro-banner.png")
         String key,
-        @io.swagger.v3.oas.annotations.media.Schema(description = "S3 PUT 업로드용 presigned URL", example = "https://bucket.s3.amazonaws.com/...")
+
+        @Schema(description = "S3 PUT 업로드용 presigned URL", example = "https://bucket.s3.amazonaws.com/...")
         String uploadUrl,
-        @io.swagger.v3.oas.annotations.media.Schema(description = "presign 만료 시간(초)", example = "300")
+
+        @Schema(description = "presign 만료 시간(초)", example = "300")
         Long expiresInSeconds
 ) {
 }

--- a/src/main/java/com/example/cowmjucraft/domain/media/service/MediaService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/media/service/MediaService.java
@@ -47,17 +47,7 @@ public class MediaService {
                 request.contentType()
         );
 
-        Media media = new Media(
-                presign.key(),
-                originalFileName,
-                request.contentType(),
-                request.usageType(),
-                request.visibility()
-        );
-        mediaRepository.save(media);
-
         return new AdminMediaPresignResponseDto(
-                media.getId(),
                 presign.key(),
                 presign.uploadUrl(),
                 expireSeconds
@@ -75,17 +65,6 @@ public class MediaService {
     public MediaMetadataResponseDto getPublicMetadata(Long mediaId) {
         Media media = getPublicActiveMedia(mediaId);
         return MediaMetadataResponseDto.from(media);
-    }
-
-    public void activate(Long mediaId) {
-        // TODO: 현재는 수동 호출 방식; introduce/project 저장 성공 시 내부 서비스에서 자동 활성화되도록 연결 개선 필요.
-        Media media = getMediaOrThrow(mediaId);
-        if (media.getStatus() == MediaStatus.DELETED) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Media not found");
-        }
-        if (media.getStatus() != MediaStatus.ACTIVE) {
-            media.activate();
-        }
     }
 
     public void delete(Long mediaId) {


### PR DESCRIPTION
media presign 업로드 흐름을 정리하고, 더 이상 사용되지 않는 activate 로직을 제거했습니다.

- presign 단계에서 DB 저장 없이 S3 presigned PUT URL만 발급하도록 흐름 정리
- media activate API 및 관련 로직 제거
- presign key 생성 책임을 S3PresignService로 일원화
- usageType 기반 prefix 구조 도입을 위한 기반 작업