### PR TITLE
feat: 명지공방 소개(Introduce) Public/Admin API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,19 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation('org.springframework.boot:spring-boot-starter-web') {
+		exclude group: 'tools.jackson', module: 'jackson-bom'
+		exclude group: 'tools.jackson.core', module: 'jackson-core'
+		exclude group: 'tools.jackson.core', module: 'jackson-databind'
+		exclude group: 'tools.jackson.core', module: 'jackson-annotations'
+	}
+
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
+
+	implementation platform('com.fasterxml.jackson:jackson-bom:2.20.1')
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/controller/admin/AdminIntroduceController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/controller/admin/AdminIntroduceController.java
@@ -1,0 +1,38 @@
+package com.example.cowmjucraft.domain.introduce.controller.admin;
+
+import com.example.cowmjucraft.domain.introduce.dto.request.AdminIntroduceUpsertRequest;
+import com.example.cowmjucraft.domain.introduce.dto.response.AdminIntroduceResponse;
+import com.example.cowmjucraft.domain.introduce.service.IntroduceService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/admin/introduce")
+public class AdminIntroduceController implements AdminIntroduceControllerDocs {
+
+    private final IntroduceService introduceService;
+
+    @GetMapping
+    @Override
+    public ApiResult<AdminIntroduceResponse> getIntroduce() {
+        // TODO: apply admin authorization policy
+        return ApiResult.success(SuccessType.SUCCESS, introduceService.adminGet());
+    }
+
+    @PutMapping
+    @Override
+    public ApiResult<AdminIntroduceResponse> upsertIntroduce(
+            @Valid @RequestBody AdminIntroduceUpsertRequest request
+    ) {
+        // TODO: apply admin authorization policy
+        return ApiResult.success(SuccessType.SUCCESS, introduceService.adminUpsert(request));
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/controller/admin/AdminIntroduceControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/controller/admin/AdminIntroduceControllerDocs.java
@@ -1,0 +1,48 @@
+package com.example.cowmjucraft.domain.introduce.controller.admin;
+
+import com.example.cowmjucraft.domain.introduce.dto.request.AdminIntroduceUpsertRequest;
+import com.example.cowmjucraft.domain.introduce.dto.response.AdminIntroduceResponse;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Introduce - Admin", description = "소개 관리자 API")
+public interface AdminIntroduceControllerDocs {
+
+    @Operation(
+            summary = "소개 원본 조회",
+            description = "관리자 편집용 원본 데이터를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "리소스 없음")
+    })
+    ApiResult<AdminIntroduceResponse> getIntroduce();
+
+    @Operation(
+            summary = "소개 원본 저장",
+            description = "소개 데이터를 전체 덮어쓰기 방식으로 저장합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    ApiResult<AdminIntroduceResponse> upsertIntroduce(
+            @Valid @RequestBody AdminIntroduceUpsertRequest request
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/controller/client/IntroduceController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/controller/client/IntroduceController.java
@@ -1,0 +1,31 @@
+package com.example.cowmjucraft.domain.introduce.controller.client;
+
+import com.example.cowmjucraft.domain.introduce.dto.response.IntroduceDetailResponse;
+import com.example.cowmjucraft.domain.introduce.dto.response.IntroduceMainSummaryResponse;
+import com.example.cowmjucraft.domain.introduce.service.IntroduceService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/introduce")
+public class IntroduceController implements IntroduceControllerDocs {
+
+    private final IntroduceService introduceService;
+
+    @GetMapping("/main")
+    @Override
+    public ApiResult<IntroduceMainSummaryResponse> getMainSummary() {
+        return ApiResult.success(SuccessType.SUCCESS, introduceService.getMainSummary());
+    }
+
+    @GetMapping
+    @Override
+    public ApiResult<IntroduceDetailResponse> getDetail() {
+        return ApiResult.success(SuccessType.SUCCESS, introduceService.getDetail());
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/controller/client/IntroduceControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/controller/client/IntroduceControllerDocs.java
@@ -1,0 +1,43 @@
+package com.example.cowmjucraft.domain.introduce.controller.client;
+
+import com.example.cowmjucraft.domain.introduce.dto.response.IntroduceDetailResponse;
+import com.example.cowmjucraft.domain.introduce.dto.response.IntroduceMainSummaryResponse;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Introduce - Public", description = "소개 조회 API")
+public interface IntroduceControllerDocs {
+
+    @Operation(
+            summary = "소개 메인 요약 조회",
+            description = "메인 화면 요약 정보 및 히어로 로고 key 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "리소스 없음")
+    })
+    ApiResult<IntroduceMainSummaryResponse> getMainSummary();
+
+    @Operation(
+            summary = "소개 상세 조회",
+            description = "소개 상세 섹션 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "리소스 없음")
+    })
+    ApiResult<IntroduceDetailResponse> getDetail();
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/dto/request/AdminIntroduceUpsertRequest.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/dto/request/AdminIntroduceUpsertRequest.java
@@ -1,0 +1,32 @@
+package com.example.cowmjucraft.domain.introduce.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "소개 관리자 저장(전체 덮어쓰기) 요청 DTO")
+public record AdminIntroduceUpsertRequest(
+
+        @NotBlank
+        @Schema(description = "제목", example = "명지공방 소개")
+        String title,
+
+        @Schema(description = "부제목", example = "우리의 방향과 비전", nullable = true)
+        String subtitle,
+
+        @Schema(description = "요약", example = "명지공방은 ...", nullable = true)
+        String summary,
+
+        @Schema(description = "메인 히어로 로고 S3 object key 목록", nullable = true)
+        List<String> heroLogoKeys,
+
+        @NotNull
+        @NotEmpty
+        @Schema(description = "소개 섹션 목록 (type 필드 포함)")
+        List<Map<String, Object>> sections
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/dto/response/AdminIntroduceResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/dto/response/AdminIntroduceResponse.java
@@ -1,0 +1,30 @@
+package com.example.cowmjucraft.domain.introduce.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "소개 관리자 조회 응답 DTO")
+public record AdminIntroduceResponse(
+
+        @Schema(description = "제목", example = "명지공방 소개")
+        String title,
+
+        @Schema(description = "부제목", example = "우리의 방향과 비전")
+        String subtitle,
+
+        @Schema(description = "요약", example = "명지공방은 ...")
+        String summary,
+
+        @Schema(description = "메인 히어로 로고 S3 object key 목록")
+        List<String> heroLogoKeys,
+
+        @Schema(description = "소개 섹션 목록 (type 필드 포함)")
+        List<Map<String, Object>> sections,
+
+        @Schema(description = "최종 수정 시각")
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/dto/response/IntroduceDetailResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/dto/response/IntroduceDetailResponse.java
@@ -1,0 +1,14 @@
+package com.example.cowmjucraft.domain.introduce.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "소개 상세 응답 DTO")
+public record IntroduceDetailResponse(
+
+        @Schema(description = "소개 섹션 목록 (type 필드 포함)")
+        List<Map<String, Object>> sections
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/dto/response/IntroduceMainSummaryResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/dto/response/IntroduceMainSummaryResponse.java
@@ -1,0 +1,22 @@
+package com.example.cowmjucraft.domain.introduce.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "소개 메인 요약 응답 DTO")
+public record IntroduceMainSummaryResponse(
+
+        @Schema(description = "제목", example = "명지공방 소개")
+        String title,
+
+        @Schema(description = "부제목", example = "우리의 방향과 비전")
+        String subtitle,
+
+        @Schema(description = "요약", example = "명지공방은 ...")
+        String summary,
+
+        @Schema(description = "메인 히어로 로고 S3 object key 목록")
+        List<String> heroLogoKeys
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/entity/Introduce.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/entity/Introduce.java
@@ -1,0 +1,70 @@
+package com.example.cowmjucraft.domain.introduce.entity;
+
+import com.example.cowmjucraft.domain.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "introduce")
+public class Introduce extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(length = 200)
+    private String subtitle;
+
+    @Column(length = 255)
+    private String summary;
+
+    @Column(name = "hero_logo_keys", columnDefinition = "json")
+    private String heroLogoKeysJson;
+
+    @Column(name = "sections", columnDefinition = "json", nullable = false)
+    private String sectionsJson;
+
+    @Version
+    private Integer version;
+
+    public Introduce(
+            String title,
+            String subtitle,
+            String summary,
+            String heroLogoKeysJson,
+            String sectionsJson
+    ) {
+        this.title = title;
+        this.subtitle = subtitle;
+        this.summary = summary;
+        this.heroLogoKeysJson = heroLogoKeysJson;
+        this.sectionsJson = sectionsJson;
+    }
+
+    public void update(
+            String title,
+            String subtitle,
+            String summary,
+            String heroLogoKeysJson,
+            String sectionsJson
+    ) {
+        this.title = title;
+        this.subtitle = subtitle;
+        this.summary = summary;
+        this.heroLogoKeysJson = heroLogoKeysJson;
+        this.sectionsJson = sectionsJson;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/repository/IntroduceRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/repository/IntroduceRepository.java
@@ -1,0 +1,11 @@
+package com.example.cowmjucraft.domain.introduce.repository;
+
+import com.example.cowmjucraft.domain.introduce.entity.Introduce;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface IntroduceRepository extends JpaRepository<Introduce, Long> {
+
+    Optional<Introduce> findTopByOrderByIdAsc();
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/section/IntroduceSectionType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/section/IntroduceSectionType.java
@@ -1,0 +1,8 @@
+package com.example.cowmjucraft.domain.introduce.section;
+
+public enum IntroduceSectionType {
+    HEADER,
+    PURPOSE,
+    CURRENT_LOGO,
+    LOGO_HISTORY
+}

--- a/src/main/java/com/example/cowmjucraft/domain/introduce/service/IntroduceService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/introduce/service/IntroduceService.java
@@ -1,0 +1,191 @@
+package com.example.cowmjucraft.domain.introduce.service;
+
+import com.example.cowmjucraft.domain.introduce.dto.request.AdminIntroduceUpsertRequest;
+import com.example.cowmjucraft.domain.introduce.dto.response.AdminIntroduceResponse;
+import com.example.cowmjucraft.domain.introduce.dto.response.IntroduceDetailResponse;
+import com.example.cowmjucraft.domain.introduce.dto.response.IntroduceMainSummaryResponse;
+import com.example.cowmjucraft.domain.introduce.entity.Introduce;
+import com.example.cowmjucraft.domain.introduce.repository.IntroduceRepository;
+import com.example.cowmjucraft.domain.introduce.section.IntroduceSectionType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class IntroduceService {
+
+    private static final Long INTRODUCE_ID = 1L;
+
+    private final IntroduceRepository introduceRepository;
+    private final IntroduceJsonCodec jsonCodec;
+
+    public IntroduceService(IntroduceRepository introduceRepository, ObjectMapper objectMapper) {
+        this.introduceRepository = introduceRepository;
+        this.jsonCodec = new IntroduceJsonCodec(objectMapper);
+    }
+
+    @Transactional(readOnly = true)
+    public IntroduceMainSummaryResponse getMainSummary() {
+        Introduce introduce = getIntroduceOrThrow();
+        return new IntroduceMainSummaryResponse(
+                introduce.getTitle(),
+                introduce.getSubtitle(),
+                introduce.getSummary(),
+                jsonCodec.readHeroLogoKeys(introduce.getHeroLogoKeysJson())
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public IntroduceDetailResponse getDetail() {
+        Introduce introduce = getIntroduceOrThrow();
+        return new IntroduceDetailResponse(jsonCodec.readSections(introduce.getSectionsJson()));
+    }
+
+    @Transactional(readOnly = true)
+    public AdminIntroduceResponse adminGet() {
+        Introduce introduce = getIntroduceOrThrow();
+        return new AdminIntroduceResponse(
+                introduce.getTitle(),
+                introduce.getSubtitle(),
+                introduce.getSummary(),
+                jsonCodec.readHeroLogoKeys(introduce.getHeroLogoKeysJson()),
+                jsonCodec.readSections(introduce.getSectionsJson()),
+                introduce.getUpdatedAt()
+        );
+    }
+
+    @Transactional
+    public AdminIntroduceResponse adminUpsert(AdminIntroduceUpsertRequest request) {
+        validateSections(request.sections());
+
+        String heroLogoKeysJson = jsonCodec.writeJson(request.heroLogoKeys());
+        String sectionsJson = jsonCodec.writeJson(request.sections());
+
+        Introduce introduce = introduceRepository.findById(INTRODUCE_ID)
+                .orElseGet(() -> new Introduce(
+                        request.title(),
+                        request.subtitle(),
+                        request.summary(),
+                        heroLogoKeysJson,
+                        sectionsJson
+                ));
+
+        introduce.update(
+                request.title(),
+                request.subtitle(),
+                request.summary(),
+                heroLogoKeysJson,
+                sectionsJson
+        );
+
+        introduceRepository.save(introduce);
+
+        return new AdminIntroduceResponse(
+                introduce.getTitle(),
+                introduce.getSubtitle(),
+                introduce.getSummary(),
+                jsonCodec.readHeroLogoKeys(introduce.getHeroLogoKeysJson()),
+                jsonCodec.readSections(introduce.getSectionsJson()),
+                introduce.getUpdatedAt()
+        );
+    }
+
+    private Introduce getIntroduceOrThrow() {
+        return introduceRepository.findById(INTRODUCE_ID)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "introduce not found"));
+    }
+
+    private void validateSections(List<Map<String, Object>> sections) {
+        if (sections == null || sections.isEmpty()) {
+            throw badRequest("sections are required");
+        }
+
+        for (int i = 0; i < sections.size(); i++) {
+            Map<String, Object> section = sections.get(i);
+
+            Object typeObj = section.get("type");
+            if (!(typeObj instanceof String)) {
+                throw badRequest(errTypeRequired(i));
+            }
+
+            String typeText = ((String) typeObj).trim();
+            if (typeText.isEmpty()) {
+                throw badRequest(errTypeRequired(i));
+            }
+
+            try {
+                IntroduceSectionType.valueOf(typeText);
+            } catch (IllegalArgumentException e) {
+                throw badRequest(errInvalidType(i, typeText));
+            }
+
+            // TODO: 섹션별 필수 필드 검증은 여기서 확장
+        }
+    }
+
+    private ResponseStatusException badRequest(String msg) {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, msg);
+    }
+
+    private String errTypeRequired(int idx) {
+        return "sections[" + idx + "].type is required (allowed: " + allowedTypes() + ")";
+    }
+
+    private String errInvalidType(int idx, String value) {
+        return "sections[" + idx + "].type is invalid: " + value + " (allowed: " + allowedTypes() + ")";
+    }
+
+    private String allowedTypes() {
+        return Arrays.stream(IntroduceSectionType.values())
+                .map(Enum::name)
+                .collect(Collectors.joining(", "));
+    }
+
+    private static final class IntroduceJsonCodec {
+
+        private static final TypeReference<List<String>> HERO_LOGO_KEYS_TYPE = new TypeReference<>() {};
+        private static final TypeReference<List<Map<String, Object>>> SECTIONS_TYPE = new TypeReference<>() {};
+
+        private final ObjectMapper objectMapper;
+
+        private IntroduceJsonCodec(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
+
+        private List<String> readHeroLogoKeys(String json) {
+            if (json == null) return null;
+            try {
+                return objectMapper.readValue(json, HERO_LOGO_KEYS_TYPE);
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("Failed to parse heroLogoKeysJson", e);
+            }
+        }
+
+        private List<Map<String, Object>> readSections(String json) {
+            if (json == null) return List.of();
+            try {
+                return objectMapper.readValue(json, SECTIONS_TYPE);
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("Failed to parse sectionsJson", e);
+            }
+        }
+
+        private String writeJson(Object value) {
+            if (value == null) return null;
+            try {
+                return objectMapper.writeValueAsString(value);
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("Failed to serialize introduce payload", e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/config/JacksonConfig.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/JacksonConfig.java
@@ -1,0 +1,17 @@
+package com.example.cowmjucraft.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
+    }
+}


### PR DESCRIPTION
# 요약

명지공방 소개 페이지를 위한 Introduce 도메인을 구현했습니다.  
단일 리소스 기반으로 메인 페이지 요약 조회, 소개 페이지 상세 조회,
관리자 편집용 조회/수정 API를 제공합니다.

---

# 작업 내용

- Introduce 도메인 신규 구현 (단일 엔티티)
- 메인 페이지용 소개 요약 조회 API 추가
  - 타이틀 / 서브타이틀 / 요약 / 대표 로고 key 목록
- 소개 페이지 상세 조회 API 추가
  - 섹션 단위 응답 (순서 보장)
  - HEADER / PURPOSE / CURRENT_LOGO / LOGO_HISTORY 섹션 지원
- 관리자용 소개 조회 및 전체 수정(Upsert) API 추가
- 섹션 타입 Enum(IntroduceSectionType) 도입 및 유효성 검증
- 이미지/로고는 S3 URL이 아닌 object key만 저장/응답하도록 설계
- sections, heroLogoKeys JSON 직렬화/역직렬화 로직 분리(Codec)

---

# 설계 포인트

- Introduce 도메인은 단일 리소스로 관리 (id=1 고정)
- 조회 목적에 따라 DTO 분리
  - 메인 페이지 요약 DTO
  - 소개 페이지 상세 DTO
  - 관리자 편집용 원본 DTO
- 섹션 구조는 서버에서 순서를 보장하여 내려주고
  프론트는 type 기반으로 렌더링
- 미디어 URL 변환은 media presign-get(batch) API를 통해 수행

---

# 기타 (논의)

- media presign PUT batch API는 후속 PR에서 추가 예정
- 섹션별 필수 필드 검증은 필요 시 단계적으로 확장 가능

---

# 타 직군 전달 사항

- 소개/메인 페이지에서는 이미지 URL이 아닌 key를 기준으로
  media presign-get(batch) 호출이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin endpoints to manage introduction content with retrieve and update operations.
  * Added public endpoints to view introduction content, including main summary and detailed views.
  * Support for organizing introduction into typed sections and managing hero logos.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->