### PR TITLE
feat: 프로젝트 도메인 및 고정/정렬 기능 구현

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectController.java
@@ -1,0 +1,62 @@
+package com.example.cowmjucraft.domain.project.controller.admin;
+
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectCreateRequestDto;
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectUpdateRequestDto;
+import com.example.cowmjucraft.domain.project.dto.response.AdminProjectOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.project.dto.response.AdminProjectResponseDto;
+import com.example.cowmjucraft.domain.project.service.AdminProjectService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/admin/projects")
+public class AdminProjectController implements AdminProjectControllerDocs {
+
+    private final AdminProjectService adminProjectService;
+
+    @PostMapping
+    @Override
+    public ApiResult<AdminProjectResponseDto> createProject(
+            @Valid @RequestBody AdminProjectCreateRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.CREATED, adminProjectService.create(request));
+    }
+
+    @PutMapping("/{projectId}")
+    @Override
+    public ApiResult<AdminProjectResponseDto> updateProject(
+            @PathVariable Long projectId,
+            @Valid @RequestBody AdminProjectUpdateRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminProjectService.update(projectId, request));
+    }
+
+    @DeleteMapping("/{projectId}")
+    @Override
+    public ApiResult<?> deleteProject(
+            @PathVariable Long projectId
+    ) {
+        adminProjectService.delete(projectId);
+        return ApiResult.success(SuccessType.NO_CONTENT);
+    }
+
+    @PatchMapping("/order")
+    @Override
+    public ApiResult<AdminProjectOrderPatchResponseDto> patchOrder(
+            @Valid @RequestBody AdminProjectOrderPatchRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminProjectService.patchOrder(request));
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
@@ -1,0 +1,173 @@
+package com.example.cowmjucraft.domain.project.controller.admin;
+
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectCreateRequestDto;
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectUpdateRequestDto;
+import com.example.cowmjucraft.domain.project.dto.response.AdminProjectOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.project.dto.response.AdminProjectResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.validation.Valid;
+
+@Tag(name = "Project - Admin", description = "프로젝트 관리자 API")
+public interface AdminProjectControllerDocs {
+
+    @Operation(
+            summary = "프로젝트 생성",
+            description = "프로젝트 기본 정보를 생성합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "프로젝트 생성 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminProjectCreateRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "create-request",
+                            value = """
+                                    {
+                                      "title": "명지공방 머그컵 프로젝트",
+                                      "summary": "캠퍼스 감성을 담은 머그컵을 제작합니다.",
+                                      "description": "학생들이 함께 디자인한 머그컵 프로젝트입니다.",
+                                      "thumbnailKey": "uploads/projects/thumbnail-001.png",
+                                      "deadlineDate": "2026-03-15",
+                                      "status": "OPEN"
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<AdminProjectResponseDto> createProject(
+            @Valid AdminProjectCreateRequestDto request
+    );
+
+    @Operation(
+            summary = "프로젝트 수정",
+            description = "프로젝트 기본 정보를 수정합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "프로젝트 수정 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminProjectUpdateRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "update-request",
+                            value = """
+                                    {
+                                      "title": "명지공방 머그컵 프로젝트 (리뉴얼)",
+                                      "summary": "굿즈 라인업을 확장합니다.",
+                                      "description": "학생들이 함께 디자인한 머그컵 프로젝트입니다.",
+                                      "thumbnailKey": "uploads/projects/thumbnail-001.png",
+                                      "deadlineDate": "2026-03-20",
+                                      "status": "OPEN"
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<AdminProjectResponseDto> updateProject(
+            @Parameter(description = "프로젝트 ID", example = "1")
+            Long projectId,
+            @Valid AdminProjectUpdateRequestDto request
+    );
+
+    @Operation(
+            summary = "프로젝트 삭제",
+            description = "프로젝트를 삭제합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
+    })
+    ApiResult<?> deleteProject(
+            @Parameter(description = "프로젝트 ID", example = "1")
+            Long projectId
+    );
+
+    @Operation(
+            summary = "프로젝트 고정/정렬 일괄 변경",
+            description = """
+                    고정 여부 및 정렬 순서를 일괄로 반영합니다.
+                    items에 포함된 프로젝트만 갱신되며, 포함되지 않은 프로젝트는 기존 값을 유지합니다.
+                    pinned=false & manualOrder=null 인 경우 자동정렬 대상으로 저장됩니다.
+                    manualOrder는 1 이상이며 pinned=true일 때는 manualOrder를 보낼 수 없습니다.
+                    """
+    )
+    @RequestBody(
+            required = true,
+            description = "프로젝트 고정/정렬 변경 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminProjectOrderPatchRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "order-request",
+                            value = """
+                                    {
+                                      "items": [
+                                        { "projectId": 3, "pinned": true },
+                                        { "projectId": 1, "pinned": true },
+                                        { "projectId": 7, "pinned": true },
+                                        { "projectId": 10, "pinned": false, "manualOrder": 1 },
+                                        { "projectId": 12, "pinned": false, "manualOrder": 2 }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "order-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "요청에 성공하였습니다.",
+                                              "data": {
+                                                "updatedPinnedCount": 3,
+                                                "updatedManualCount": 2
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<AdminProjectOrderPatchResponseDto> patchOrder(
+            @Valid AdminProjectOrderPatchRequestDto request
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/client/ProjectController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/client/ProjectController.java
@@ -1,0 +1,35 @@
+package com.example.cowmjucraft.domain.project.controller.client;
+
+import com.example.cowmjucraft.domain.project.dto.response.ProjectDetailResponseDto;
+import com.example.cowmjucraft.domain.project.dto.response.ProjectListItemResponseDto;
+import com.example.cowmjucraft.domain.project.service.ProjectService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectController implements ProjectControllerDocs {
+
+    private final ProjectService projectService;
+
+    @GetMapping
+    @Override
+    public ApiResult<List<ProjectListItemResponseDto>> getProjects() {
+        return ApiResult.success(SuccessType.SUCCESS, projectService.getProjects());
+    }
+
+    @GetMapping("/{projectId}")
+    @Override
+    public ApiResult<ProjectDetailResponseDto> getProject(
+            @PathVariable Long projectId
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, projectService.getProject(projectId));
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/client/ProjectControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/client/ProjectControllerDocs.java
@@ -1,0 +1,47 @@
+package com.example.cowmjucraft.domain.project.controller.client;
+
+import com.example.cowmjucraft.domain.project.dto.response.ProjectDetailResponseDto;
+import com.example.cowmjucraft.domain.project.dto.response.ProjectListItemResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+
+@Tag(name = "Project - Public", description = "프로젝트 공개 조회 API")
+public interface ProjectControllerDocs {
+
+    @Operation(
+            summary = "프로젝트 목록 조회",
+            description = "고정/마감일/수동정렬 규칙에 따라 프로젝트 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            )
+    })
+    ApiResult<List<ProjectListItemResponseDto>> getProjects();
+
+    @Operation(
+            summary = "프로젝트 상세 조회",
+            description = "프로젝트 상세 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
+    })
+    ApiResult<ProjectDetailResponseDto> getProject(
+            @Parameter(description = "프로젝트 ID", example = "1")
+            Long projectId
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectCreateRequestDto.java
@@ -1,0 +1,40 @@
+package com.example.cowmjucraft.domain.project.dto.request;
+
+import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+@Schema(description = "프로젝트 생성 요청")
+public record AdminProjectCreateRequestDto(
+
+        @NotBlank
+        @Size(max = 100)
+        @Schema(description = "프로젝트 제목", example = "명지공방 머그컵 프로젝트")
+        String title,
+
+        @NotBlank
+        @Size(max = 255)
+        @Schema(description = "리스트 한줄 소개", example = "캠퍼스 감성을 담은 머그컵을 제작합니다.")
+        String summary,
+
+        @NotBlank
+        @Schema(description = "프로젝트 상세 설명", example = "학생들이 함께 디자인한 머그컵 프로젝트입니다.")
+        String description,
+
+        @NotBlank
+        @Size(max = 255)
+        @Schema(description = "썸네일 S3 key", example = "uploads/projects/thumbnail-001.png")
+        String thumbnailKey,
+
+        @NotNull
+        @Schema(description = "마감일 (YYYY-MM-DD)", example = "2026-03-15")
+        LocalDate deadlineDate,
+
+        @NotNull
+        @Schema(description = "프로젝트 상태", example = "OPEN")
+        ProjectStatus status
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectOrderPatchRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectOrderPatchRequestDto.java
@@ -1,0 +1,34 @@
+package com.example.cowmjucraft.domain.project.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+@Schema(description = "프로젝트 고정/정렬 일괄 변경 요청")
+public record AdminProjectOrderPatchRequestDto(
+
+        @NotNull
+        @NotEmpty
+        @Valid
+        @Schema(description = "정렬 변경 항목 목록 (빈 리스트 불가)")
+        List<ItemDto> items
+) {
+
+    @Schema(description = "정렬 변경 항목")
+    public record ItemDto(
+
+            @NotNull
+            @Schema(description = "프로젝트 ID", example = "3")
+            Long projectId,
+
+            @NotNull
+            @Schema(description = "고정 여부", example = "true")
+            Boolean pinned,
+
+            @Schema(description = "수동 정렬 순서 (pinned=false인 경우만 적용)", example = "1")
+            Integer manualOrder
+    ) {
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectUpdateRequestDto.java
@@ -1,0 +1,40 @@
+package com.example.cowmjucraft.domain.project.dto.request;
+
+import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+@Schema(description = "프로젝트 수정 요청")
+public record AdminProjectUpdateRequestDto(
+
+        @NotBlank
+        @Size(max = 100)
+        @Schema(description = "프로젝트 제목", example = "명지공방 머그컵 프로젝트")
+        String title,
+
+        @NotBlank
+        @Size(max = 255)
+        @Schema(description = "리스트 한줄 소개", example = "캠퍼스 감성을 담은 머그컵을 제작합니다.")
+        String summary,
+
+        @NotBlank
+        @Schema(description = "프로젝트 상세 설명", example = "학생들이 함께 디자인한 머그컵 프로젝트입니다.")
+        String description,
+
+        @NotBlank
+        @Size(max = 255)
+        @Schema(description = "썸네일 S3 key", example = "uploads/projects/thumbnail-001.png")
+        String thumbnailKey,
+
+        @NotNull
+        @Schema(description = "마감일 (YYYY-MM-DD)", example = "2026-03-15")
+        LocalDate deadlineDate,
+
+        @NotNull
+        @Schema(description = "프로젝트 상태", example = "OPEN")
+        ProjectStatus status
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectOrderPatchResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectOrderPatchResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.cowmjucraft.domain.project.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로젝트 고정/정렬 변경 응답")
+public record AdminProjectOrderPatchResponseDto(
+
+        @Schema(description = "고정 순서 재부여 개수", example = "3")
+        int updatedPinnedCount,
+
+        @Schema(description = "수동 정렬 변경 개수", example = "2")
+        int updatedManualCount
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectResponseDto.java
@@ -1,0 +1,47 @@
+package com.example.cowmjucraft.domain.project.dto.response;
+
+import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Schema(description = "프로젝트 관리자 응답")
+public record AdminProjectResponseDto(
+
+        @Schema(description = "프로젝트 ID", example = "1")
+        Long id,
+
+        @Schema(description = "프로젝트 제목", example = "명지공방 머그컵 프로젝트")
+        String title,
+
+        @Schema(description = "리스트 한줄 소개", example = "캠퍼스 감성을 담은 머그컵을 제작합니다.")
+        String summary,
+
+        @Schema(description = "프로젝트 상세 설명", example = "학생들이 함께 디자인한 머그컵 프로젝트입니다.")
+        String description,
+
+        @Schema(description = "썸네일 S3 key", example = "uploads/projects/thumbnail-001.png")
+        String thumbnailKey,
+
+        @Schema(description = "프로젝트 상태", example = "OPEN")
+        ProjectStatus status,
+
+        @Schema(description = "마감일 (YYYY-MM-DD)", example = "2026-03-15")
+        LocalDate deadlineDate,
+
+        @Schema(description = "고정 여부", example = "false")
+        boolean pinned,
+
+        @Schema(description = "고정 순서", example = "1")
+        Integer pinnedOrder,
+
+        @Schema(description = "수동 정렬 순서", example = "3")
+        Integer manualOrder,
+
+        @Schema(description = "생성일시")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일시")
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectDetailResponseDto.java
@@ -1,0 +1,41 @@
+package com.example.cowmjucraft.domain.project.dto.response;
+
+import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Schema(description = "프로젝트 상세 응답")
+public record ProjectDetailResponseDto(
+
+        @Schema(description = "프로젝트 ID", example = "1")
+        Long id,
+
+        @Schema(description = "프로젝트 제목", example = "명지공방 머그컵 프로젝트")
+        String title,
+
+        @Schema(description = "리스트 한줄 소개", example = "캠퍼스 감성을 담은 머그컵을 제작합니다.")
+        String summary,
+
+        @Schema(description = "프로젝트 상세 설명", example = "학생들이 함께 디자인한 머그컵 프로젝트입니다.")
+        String description,
+
+        @Schema(description = "썸네일 S3 key", example = "uploads/projects/thumbnail-001.png")
+        String thumbnailKey,
+
+        @Schema(description = "프로젝트 상태", example = "OPEN")
+        ProjectStatus status,
+
+        @Schema(description = "마감일 (YYYY-MM-DD)", example = "2026-03-15")
+        LocalDate deadlineDate,
+
+        @Schema(description = "D-day (마감일까지 남은 일수)", example = "30")
+        long dDay,
+
+        @Schema(description = "생성일시")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일시")
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectListItemResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectListItemResponseDto.java
@@ -1,0 +1,34 @@
+package com.example.cowmjucraft.domain.project.dto.response;
+
+import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+@Schema(description = "프로젝트 목록 아이템 응답")
+public record ProjectListItemResponseDto(
+
+        @Schema(description = "프로젝트 ID", example = "1")
+        Long id,
+
+        @Schema(description = "프로젝트 제목", example = "명지공방 머그컵 프로젝트")
+        String title,
+
+        @Schema(description = "리스트 한줄 소개", example = "캠퍼스 감성을 담은 머그컵을 제작합니다.")
+        String summary,
+
+        @Schema(description = "썸네일 S3 key", example = "uploads/projects/thumbnail-001.png")
+        String thumbnailKey,
+
+        @Schema(description = "프로젝트 상태", example = "OPEN")
+        ProjectStatus status,
+
+        @Schema(description = "마감일 (YYYY-MM-DD)", example = "2026-03-15")
+        LocalDate deadlineDate,
+
+        @Schema(description = "D-day (마감일까지 남은 일수)", example = "30")
+        long dDay,
+
+        @Schema(description = "고정 여부", example = "true")
+        Boolean pinned
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/entity/Project.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/entity/Project.java
@@ -1,0 +1,97 @@
+package com.example.cowmjucraft.domain.project.entity;
+
+import com.example.cowmjucraft.domain.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "projects")
+public class Project extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(length = 255, nullable = false)
+    private String summary;
+
+    @Lob
+    @Column(nullable = false)
+    private String description;
+
+    @Column(length = 255, nullable = false)
+    private String thumbnailKey;
+
+    @Column(nullable = false)
+    private LocalDate deadlineDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProjectStatus status;
+
+    @Column(nullable = false)
+    private boolean pinned = false;
+
+    @Column
+    private Integer pinnedOrder;
+
+    @Column
+    private Integer manualOrder;
+
+    public Project(
+            String title,
+            String summary,
+            String description,
+            String thumbnailKey,
+            LocalDate deadlineDate,
+            ProjectStatus status
+    ) {
+        this.title = title;
+        this.summary = summary;
+        this.description = description;
+        this.thumbnailKey = thumbnailKey;
+        this.deadlineDate = deadlineDate;
+        this.status = status;
+    }
+
+    public void updateBasic(
+            String title,
+            String summary,
+            String description,
+            String thumbnailKey,
+            LocalDate deadlineDate,
+            ProjectStatus status
+    ) {
+        this.title = title;
+        this.summary = summary;
+        this.description = description;
+        this.thumbnailKey = thumbnailKey;
+        this.deadlineDate = deadlineDate;
+        this.status = status;
+    }
+
+    public void applyPinned(boolean pinned, Integer pinnedOrder) {
+        this.pinned = pinned;
+        this.pinnedOrder = pinnedOrder;
+    }
+
+    public void applyManualOrder(Integer manualOrder) {
+        this.manualOrder = manualOrder;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/entity/ProjectStatus.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/entity/ProjectStatus.java
@@ -1,0 +1,7 @@
+package com.example.cowmjucraft.domain.project.entity;
+
+public enum ProjectStatus {
+    PREPARING,
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,23 @@
+package com.example.cowmjucraft.domain.project.repository;
+
+import com.example.cowmjucraft.domain.project.entity.Project;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    @Query("""
+    select p from Project p
+    order by
+        case when p.pinned = true then 0 else 1 end,
+        case when p.pinned = true and p.pinnedOrder is null then 1 else 0 end,
+        case when p.pinned = true then p.pinnedOrder else null end,
+        case when p.pinned = false then p.deadlineDate else null end,
+        case when p.pinned = false and p.manualOrder is null then 1 else 0 end,
+        case when p.pinned = false then p.manualOrder else null end,
+        p.createdAt desc,
+        p.id desc
+""")
+    List<Project> findAllOrderedForPublic();
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/service/AdminProjectService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/service/AdminProjectService.java
@@ -1,0 +1,157 @@
+package com.example.cowmjucraft.domain.project.service;
+
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectCreateRequestDto;
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectUpdateRequestDto;
+import com.example.cowmjucraft.domain.project.dto.response.AdminProjectOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.project.dto.response.AdminProjectResponseDto;
+import com.example.cowmjucraft.domain.project.entity.Project;
+import com.example.cowmjucraft.domain.project.repository.ProjectRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class AdminProjectService {
+
+    private final ProjectRepository projectRepository;
+
+    public AdminProjectService(ProjectRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    @Transactional
+    public AdminProjectResponseDto create(AdminProjectCreateRequestDto request) {
+        Project project = new Project(
+                request.title(),
+                request.summary(),
+                request.description(),
+                request.thumbnailKey(),
+                request.deadlineDate(),
+                request.status()
+        );
+        Project saved = projectRepository.save(project);
+        return toAdminResponse(saved);
+    }
+
+    @Transactional
+    public AdminProjectResponseDto update(Long projectId, AdminProjectUpdateRequestDto request) {
+        Project project = findProject(projectId);
+        project.updateBasic(
+                request.title(),
+                request.summary(),
+                request.description(),
+                request.thumbnailKey(),
+                request.deadlineDate(),
+                request.status()
+        );
+        return toAdminResponse(project);
+    }
+
+    @Transactional
+    public void delete(Long projectId) {
+        Project project = findProject(projectId);
+        projectRepository.delete(project);
+    }
+
+    @Transactional
+    public AdminProjectOrderPatchResponseDto patchOrder(AdminProjectOrderPatchRequestDto request) {
+        List<AdminProjectOrderPatchRequestDto.ItemDto> items = request.items();
+        if (items == null) {
+            throw validationFailed("items are required");
+        }
+
+        Set<Long> ids = new HashSet<>();
+        for (AdminProjectOrderPatchRequestDto.ItemDto item : items) {
+            if (!ids.add(item.projectId())) {
+                throw validationFailed("duplicate projectId: " + item.projectId());
+            }
+        }
+
+        validateManualOrders(items);
+
+        List<Project> projects = projectRepository.findAllById(ids);
+        if (projects.size() != ids.size()) {
+            Set<Long> foundIds = projects.stream().map(Project::getId).collect(Collectors.toSet());
+            ids.removeAll(foundIds);
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "project not found: " + ids);
+        }
+
+        Map<Long, Project> projectMap = projects.stream()
+                .collect(Collectors.toMap(Project::getId, Function.identity()));
+
+        int pinnedOrder = 0;
+        int updatedPinnedCount = 0;
+        int updatedManualCount = 0;
+
+        for (AdminProjectOrderPatchRequestDto.ItemDto item : items) {
+            Project project = projectMap.get(item.projectId());
+            if (Boolean.TRUE.equals(item.pinned())) {
+                pinnedOrder++;
+                project.applyPinned(true, pinnedOrder);
+                updatedPinnedCount++;
+            } else {
+                project.applyPinned(false, null);
+                project.applyManualOrder(item.manualOrder());
+                updatedManualCount++;
+            }
+        }
+
+        projectRepository.saveAll(projects);
+
+        return new AdminProjectOrderPatchResponseDto(updatedPinnedCount, updatedManualCount);
+    }
+
+    private Project findProject(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "project not found"));
+    }
+
+    private void validateManualOrders(List<AdminProjectOrderPatchRequestDto.ItemDto> items) {
+        Set<Integer> manualOrders = new HashSet<>();
+        for (AdminProjectOrderPatchRequestDto.ItemDto item : items) {
+            if (Boolean.TRUE.equals(item.pinned())) {
+                if (item.manualOrder() != null) {
+                    throw validationFailed("manualOrder must be null when pinned=true");
+                }
+                continue;
+            }
+
+            Integer manualOrder = item.manualOrder();
+            if (manualOrder != null && manualOrder < 1) {
+                throw validationFailed("manualOrder must be >= 1");
+            }
+            if (manualOrder != null && !manualOrders.add(manualOrder)) {
+                throw validationFailed("duplicate manualOrder: " + manualOrder);
+            }
+        }
+    }
+
+    private ResponseStatusException validationFailed(String message) {
+        return new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, message);
+    }
+
+    private AdminProjectResponseDto toAdminResponse(Project project) {
+        return new AdminProjectResponseDto(
+                project.getId(),
+                project.getTitle(),
+                project.getSummary(),
+                project.getDescription(),
+                project.getThumbnailKey(),
+                project.getStatus(),
+                project.getDeadlineDate(),
+                project.isPinned(),
+                project.getPinnedOrder(),
+                project.getManualOrder(),
+                project.getCreatedAt(),
+                project.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/service/ProjectService.java
@@ -1,0 +1,63 @@
+package com.example.cowmjucraft.domain.project.service;
+
+import com.example.cowmjucraft.domain.project.dto.response.ProjectDetailResponseDto;
+import com.example.cowmjucraft.domain.project.dto.response.ProjectListItemResponseDto;
+import com.example.cowmjucraft.domain.project.entity.Project;
+import com.example.cowmjucraft.domain.project.repository.ProjectRepository;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+
+    public ProjectService(ProjectRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectListItemResponseDto> getProjects() {
+        List<Project> projects = projectRepository.findAllOrderedForPublic();
+        return projects.stream()
+                .map(project -> new ProjectListItemResponseDto(
+                        project.getId(),
+                        project.getTitle(),
+                        project.getSummary(),
+                        project.getThumbnailKey(),
+                        project.getStatus(),
+                        project.getDeadlineDate(),
+                        calculateDDay(project.getDeadlineDate()),
+                        project.isPinned()
+                ))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectDetailResponseDto getProject(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "project not found"));
+
+        return new ProjectDetailResponseDto(
+                project.getId(),
+                project.getTitle(),
+                project.getSummary(),
+                project.getDescription(),
+                project.getThumbnailKey(),
+                project.getStatus(),
+                project.getDeadlineDate(),
+                calculateDDay(project.getDeadlineDate()),
+                project.getCreatedAt(),
+                project.getUpdatedAt()
+        );
+    }
+
+    private long calculateDDay(LocalDate deadlineDate) {
+        return ChronoUnit.DAYS.between(LocalDate.now(), deadlineDate);
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/cowmjucraft/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.example.cowmjucraft.domain.media.exception;
+package com.example.cowmjucraft.global.exception;
 
 import com.example.cowmjucraft.global.response.ApiResult;
 import com.example.cowmjucraft.global.response.type.ErrorType;
@@ -18,8 +18,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 
-@RestControllerAdvice(basePackages = "com.example.cowmjucraft.domain.media")
-public class MediaExceptionHandler {
+@RestControllerAdvice
+public class GlobalExceptionHandler {
 
     private static final int MAX_ERROR_DETAILS = 5;
 
@@ -31,7 +31,7 @@ public class MediaExceptionHandler {
 
         String detail = buildFieldErrorDetail(bindingResult);
         String message = buildValidationMessage(detail);
-        return errorResponse(ErrorType.VALIDATION_FAILED, message);
+        return errorResponse(ErrorType.INVALID_REQUEST, message);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
@@ -43,13 +43,13 @@ public class MediaExceptionHandler {
         }
         String detail = summarizeDetails(details);
         String message = buildValidationMessage(detail);
-        return errorResponse(ErrorType.VALIDATION_FAILED, message);
+        return errorResponse(ErrorType.INVALID_REQUEST, message);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResult<?>> handleNotReadable(HttpMessageNotReadableException exception) {
         return errorResponse(
-                ErrorType.VALIDATION_FAILED,
+                ErrorType.INVALID_REQUEST,
                 "요청 값 검증에 실패했습니다. (요청 본문 형식이 올바르지 않습니다)"
         );
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: false
 
 admin:


### PR DESCRIPTION
# 요약

프로젝트 도메인 기본 구조를 구현하고,  
관리자 기준 프로젝트 고정/정렬 정책과 공개 목록 조회 기능을 추가했습니다.

---

# 작업 내용

- 프로젝트 도메인 설계 및 엔티티 구현
  - Project 엔티티 및 상태(ProjectStatus) 정의
  - 마감일 기반 D-day 계산 방식 적용

- 프로젝트 조회 API 구현 (Public)
  - 프로젝트 목록 조회 (고정 → 마감 임박 → 수동 순서 정렬)
  - 프로젝트 상세 조회

- 프로젝트 관리자 API 구현 (Admin)
  - 프로젝트 생성 / 수정 / 삭제
  - 프로젝트 상단 고정 및 수동 정렬 일괄 변경 API
    - pinned 프로젝트 pinnedOrder 자동 재부여
    - 일반 프로젝트 manualOrder 적용

- 정렬 정책 서버 고정 처리
  - pinned > deadlineDate > manualOrder > createdAt 기준 정렬
  - pinnedOrder / manualOrder null 처리 정책 반영

- 전역 예외 처리 흐름 정리
  - IllegalArgumentException → 400 응답으로 통합
  - Validation / JSON 파싱 오류 처리 통합

---

# 기타 (논의하고 싶은 부분)

- 프로젝트에 포함되는 물품(Item) 도메인은 이후 단계에서 분리 구현 예정
- 프로젝트 이미지 등록은 Media 도메인의 presigned URL 방식 사용 예정

---

# 타 직군 전달 사항

- 프로젝트 목록 정렬은 서버에서 고정되어 있으며  
  프론트에서는 순서 그대로 렌더링하면 됩니다.
- 프로젝트 순서 변경은 드래그 후 **저장 버튼 클릭 시**
  `/api/admin/projects/order` API로 일괄 반영됩니다.
- D-day는 서버에서 계산되어 내려갑니다.
