### PR TITLE
feat: SNS 링크 API 단순화 및 관리자/공개 엔드포인트 분리

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/sns/controller/admin/SnsAdminController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/sns/controller/admin/SnsAdminController.java
@@ -1,29 +1,35 @@
 package com.example.cowmjucraft.domain.sns.controller.admin;
 
 import com.example.cowmjucraft.domain.sns.dto.request.SnsAdminRequestDto;
+import com.example.cowmjucraft.domain.sns.entity.SnsType;
 import com.example.cowmjucraft.domain.sns.service.SnsService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/admin")
+@RequestMapping("/api/admin/sns")
 public class SnsAdminController implements SnsAdminControllerDocs {
 
     private final SnsService snsService;
 
-    @PutMapping("/introduce/sns")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/kakao")
     @Override
-    public void replaceSnsLinks(@Valid @RequestBody List<SnsAdminRequestDto> requests) {
-        snsService.replaceAll(requests);
+    public ApiResult<?> upsertKakao(@Valid @RequestBody SnsAdminRequestDto request) {
+        snsService.upsert(SnsType.KAKAO, request);
+        return ApiResult.success(SuccessType.SUCCESS);
+    }
+
+    @PutMapping("/instagram")
+    @Override
+    public ApiResult<?> upsertInstagram(@Valid @RequestBody SnsAdminRequestDto request) {
+        snsService.upsert(SnsType.INSTAGRAM, request);
+        return ApiResult.success(SuccessType.SUCCESS);
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/sns/controller/admin/SnsAdminControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/sns/controller/admin/SnsAdminControllerDocs.java
@@ -1,44 +1,109 @@
 package com.example.cowmjucraft.domain.sns.controller.admin;
 
 import com.example.cowmjucraft.domain.sns.dto.request.SnsAdminRequestDto;
+import com.example.cowmjucraft.global.response.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import jakarta.validation.Valid;
-import java.util.List;
 
-@Tag(name = "Introduce - Admin", description = "SNS 소개 관리자 API")
+@Tag(
+        name = "SNS - Admin",
+        description = "SNS 링크 관리자 API"
+)
 public interface SnsAdminControllerDocs {
 
     @Operation(
-            summary = "SNS 링크 전체 교체",
-            description = """
-            SNS 링크를 전체 교체합니다.
-            - 요청으로 들어온 리스트가 최종 상태가 됩니다.
-            - 등록/수정/삭제를 PUT 하나로 처리합니다.
-            """
+            summary = "카카오 오픈채팅 링크 등록/수정",
+            description = "카카오 오픈채팅 링크를 등록/수정합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "성공"),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "resultType": "SUCCESS",
+                                      "httpStatusCode": 200,
+                                      "message": "요청에 성공하였습니다."
+                                    }
+                                    """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "400", description = "요청 값 검증 실패"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
-    void replaceSnsLinks(
+    ApiResult<?> upsertKakao(
             @RequestBody(
                     required = true,
-                    description = "전체 교체할 SNS 링크 목록",
+                    description = "카카오 오픈채팅 링크 정보",
                     content = @Content(
-                            array = @ArraySchema(schema = @Schema(implementation = SnsAdminRequestDto.class))
+                            schema = @Schema(implementation = SnsAdminRequestDto.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "url": "https://open.kakao.com/o/xxxx"
+                                    }
+                                    """
+                            )
                     )
             )
             @Valid
-            List<SnsAdminRequestDto> requests
+            SnsAdminRequestDto request
+    );
+
+    @Operation(
+            summary = "인스타그램 링크 등록/수정",
+            description = "인스타그램 링크를 등록/수정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "resultType": "SUCCESS",
+                                      "httpStatusCode": 200,
+                                      "message": "요청에 성공하였습니다."
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 검증 실패"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
+    ApiResult<?> upsertInstagram(
+            @RequestBody(
+                    required = true,
+                    description = "인스타그램 링크 정보",
+                    content = @Content(
+                            schema = @Schema(implementation = SnsAdminRequestDto.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "url": "https://instagram.com/mju_craft"
+                                    }
+                                    """
+                            )
+                    )
+            )
+            @Valid
+            SnsAdminRequestDto request
     );
 }

--- a/src/main/java/com/example/cowmjucraft/domain/sns/controller/client/SnsController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/sns/controller/client/SnsController.java
@@ -1,24 +1,31 @@
 package com.example.cowmjucraft.domain.sns.controller.client;
 
 import com.example.cowmjucraft.domain.sns.dto.response.SnsResponseDto;
+import com.example.cowmjucraft.domain.sns.entity.SnsType;
 import com.example.cowmjucraft.domain.sns.service.SnsService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/sns")
 public class SnsController implements SnsControllerDocs {
 
     private final SnsService snsService;
 
-    @GetMapping("/introduce/sns")
+    @GetMapping("/kakao")
     @Override
-    public List<SnsResponseDto> getSnsLinks() {
-        return snsService.getActiveSnsLinks();
+    public ApiResult<SnsResponseDto> getKakaoLink() {
+        return ApiResult.success(SuccessType.SUCCESS, snsService.getLink(SnsType.KAKAO));
+    }
+
+    @GetMapping("/instagram")
+    @Override
+    public ApiResult<SnsResponseDto> getInstagramLink() {
+        return ApiResult.success(SuccessType.SUCCESS, snsService.getLink(SnsType.INSTAGRAM));
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/sns/controller/client/SnsControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/sns/controller/client/SnsControllerDocs.java
@@ -1,29 +1,73 @@
 package com.example.cowmjucraft.domain.sns.controller.client;
 
 import com.example.cowmjucraft.domain.sns.dto.response.SnsResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 
-import java.util.List;
-
-@Tag(name = "Introduce - Public", description = "SNS 소개 조회 API")
+@Tag(name = "SNS - Public", description = "SNS 링크 조회 API")
 public interface SnsControllerDocs {
 
     @Operation(
-            summary = "SNS 링크 조회",
-            description = "활성화(active=true)된 SNS 링크를 sortOrder 오름차순으로 조회합니다."
+            summary = "카카오 오픈채팅 링크 조회",
+            description = "카카오 오픈채팅 링크를 조회합니다."
     )
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
                     description = "성공",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = SnsResponseDto.class)))
-            )
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "resultType": "SUCCESS",
+                                      "httpStatusCode": 200,
+                                      "message": "요청에 성공하였습니다.",
+                                      "data": {
+                                        "type": "KAKAO",
+                                        "url": "https://open.kakao.com/o/xxxx"
+                                      }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "리소스 없음")
     })
-    List<SnsResponseDto> getSnsLinks();
+    ApiResult<SnsResponseDto> getKakaoLink();
+
+    @Operation(
+            summary = "인스타그램 링크 조회",
+            description = "인스타그램 링크를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                      "resultType": "SUCCESS",
+                                      "httpStatusCode": 200,
+                                      "message": "요청에 성공하였습니다.",
+                                      "data": {
+                                        "type": "INSTAGRAM",
+                                        "url": "https://instagram.com/mju_craft"
+                                      }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "리소스 없음")
+    })
+    ApiResult<SnsResponseDto> getInstagramLink();
 }

--- a/src/main/java/com/example/cowmjucraft/domain/sns/dto/request/SnsAdminRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/sns/dto/request/SnsAdminRequestDto.java
@@ -1,47 +1,16 @@
 package com.example.cowmjucraft.domain.sns.dto.request;
 
-import com.example.cowmjucraft.domain.sns.entity.SnsType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "SNS 관리자 전체 교체 요청 DTO")
+@Schema(description = "SNS 관리자 단건 등록/수정 요청 DTO")
 public record SnsAdminRequestDto(
-
-        @NotNull
-        @Schema(
-                description = "SNS 타입",
-                example = "INSTAGRAM",
-                allowableValues = {"INSTAGRAM", "KAKAO", "ETC"}
-        )
-        SnsType type,
-
-        @NotBlank
-        @Schema(
-                description = "화면에 표시될 제목",
-                example = "명지공방 인스타그램"
-        )
-        String title,
 
         @NotBlank
         @Schema(
                 description = "SNS 링크 URL",
-                example = "https://instagram.com/mju_craft"
+                example = "https://open.kakao.com/o/xxxx"
         )
-        String url,
-
-        @Min(1)
-        @Schema(
-                description = "정렬 순서 (작을수록 먼저 노출)",
-                example = "1"
-        )
-        int sortOrder,
-
-        @Schema(
-                description = "노출 여부",
-                example = "true"
-        )
-        boolean active
+        String url
 ) {
 }

--- a/src/main/java/com/example/cowmjucraft/domain/sns/dto/response/SnsResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/sns/dto/response/SnsResponseDto.java
@@ -14,29 +14,15 @@ public record SnsResponseDto(
         SnsType type,
 
         @Schema(
-                description = "화면에 표시될 제목",
-                example = "명지공방 인스타그램"
-        )
-        String title,
-
-        @Schema(
                 description = "SNS 링크 URL",
                 example = "https://instagram.com/mju_craft"
         )
-        String url,
-
-        @Schema(
-                description = "프론트엔드 아이콘 매핑용 키",
-                example = "instagram"
-        )
-        String iconKey
+        String url
 ) {
     public static SnsResponseDto from(SnsLink link) {
         return new SnsResponseDto(
                 link.getType(),
-                link.getTitle(),
-                link.getUrl(),
-                link.getType().getIconKey()
+                link.getUrl()
         );
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/sns/entity/SnsLink.java
+++ b/src/main/java/com/example/cowmjucraft/domain/sns/entity/SnsLink.java
@@ -8,7 +8,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "sns_links")
+@Table(
+        name = "sns_links",
+        uniqueConstraints = @UniqueConstraint(name = "uk_sns_links_type", columnNames = "type")
+)
 public class SnsLink {
 
     @Id
@@ -20,22 +23,14 @@ public class SnsLink {
     private SnsType type;
 
     @Column(nullable = false)
-    private String title;
-
-    @Column(nullable = false)
     private String url;
 
-    @Column(nullable = false)
-    private int sortOrder;
-
-    @Column(nullable = false)
-    private boolean active;
-
-    public SnsLink(SnsType type, String title, String url, int sortOrder, boolean active) {
+    public SnsLink(SnsType type, String url) {
         this.type = type;
-        this.title = title;
         this.url = url;
-        this.sortOrder = sortOrder;
-        this.active = active;
+    }
+
+    public void updateUrl(String url) {
+        this.url = url;
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/sns/entity/SnsType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/sns/entity/SnsType.java
@@ -1,17 +1,6 @@
 package com.example.cowmjucraft.domain.sns.entity;
 
 public enum SnsType {
-    INSTAGRAM("instagram"),
-    KAKAO("kakao"),
-    ETC("etc");
-
-    private final String iconKey;
-
-    SnsType(String iconKey) {
-        this.iconKey = iconKey;
-    }
-
-    public String getIconKey() {
-        return iconKey;
-    }
+    INSTAGRAM,
+    KAKAO
 }

--- a/src/main/java/com/example/cowmjucraft/domain/sns/repository/SnsLinkRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/sns/repository/SnsLinkRepository.java
@@ -1,10 +1,12 @@
 package com.example.cowmjucraft.domain.sns.repository;
 
 import com.example.cowmjucraft.domain.sns.entity.SnsLink;
+import com.example.cowmjucraft.domain.sns.entity.SnsType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import java.util.Optional;
 
 public interface SnsLinkRepository extends JpaRepository<SnsLink, Long> {
-    List<SnsLink> findByActiveTrueOrderBySortOrderAsc();
+
+    Optional<SnsLink> findByType(SnsType type);
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: false
 
 admin:


### PR DESCRIPTION
# 요약

SNS 링크 관리 방식을 단순화하고, 관리자/공개 API를 분리하여
카카오 오픈채팅과 인스타그램 링크를 보다 명확하게 관리할 수 있도록 개선하였습니다.

# 작업 내용

- [x] SNS 링크 도메인 구조 단순화 (type + url 기준)
- [x] 관리자 SNS 링크 API 분리
  - `/api/admin/sns/kakao`
  - `/api/admin/sns/instagram`
- [x] 공개 SNS 링크 조회 API 분리
  - `/api/sns/kakao`
  - `/api/sns/instagram`
- [x] SNS 링크 upsert 로직 구현 (type 기준 단건 관리)
- [x] Swagger 태그 분리로 Admin / Public API 가독성 개선
- [x] 기존 SNS 링크 관련 코드 정리 및 불필요 필드 제거

# 기타 (논의하고 싶은 부분)

- 현재 SNS 링크는 카카오/인스타 2개 고정 구조로 설계되어 있음  
  (향후 확장 시 `{type}` 기반 엔드포인트로 변경 가능)

# 타 직군 전달 사항

- 프론트엔드에서는 관리자 SNS 설정 시 `url` 필드만 전달하면 됩니다.
- 플로팅 버튼용 SNS 링크는 아래 API를 사용해주세요.
  - 카카오: `GET /api/sns/kakao`
  - 인스타그램: `GET /api/sns/instagram`