### PR TITLE
feat: 프로젝트 물품(Item) 및 이미지 관리 API 구현

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
@@ -1,0 +1,86 @@
+package com.example.cowmjucraft.domain.item.controller.admin;
+
+import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageCreateRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemCreateRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemUpdateRequestDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminItemImageOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
+import com.example.cowmjucraft.domain.item.service.AdminItemService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/admin")
+public class AdminItemController implements AdminItemControllerDocs {
+
+    private final AdminItemService adminItemService;
+
+    @PostMapping("/projects/{projectId}/items")
+    @Override
+    public ApiResult<AdminProjectItemResponseDto> createItem(
+            @PathVariable Long projectId,
+            @Valid @RequestBody AdminProjectItemCreateRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.CREATED, adminItemService.create(projectId, request));
+    }
+
+    @PutMapping("/items/{itemId}")
+    @Override
+    public ApiResult<AdminProjectItemResponseDto> updateItem(
+            @PathVariable Long itemId,
+            @Valid @RequestBody AdminProjectItemUpdateRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminItemService.update(itemId, request));
+    }
+
+    @DeleteMapping("/items/{itemId}")
+    @Override
+    public ApiResult<?> deleteItem(
+            @PathVariable Long itemId
+    ) {
+        adminItemService.delete(itemId);
+        return ApiResult.success(SuccessType.NO_CONTENT);
+    }
+
+    @PostMapping("/items/{itemId}/images")
+    @Override
+    public ApiResult<List<ProjectItemImageResponseDto>> addImages(
+            @PathVariable Long itemId,
+            @Valid @RequestBody AdminItemImageCreateRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminItemService.addImages(itemId, request));
+    }
+
+    @PatchMapping("/items/{itemId}/images/order")
+    @Override
+    public ApiResult<AdminItemImageOrderPatchResponseDto> patchImageOrder(
+            @PathVariable Long itemId,
+            @Valid @RequestBody AdminItemImageOrderPatchRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminItemService.patchImageOrder(itemId, request));
+    }
+
+    @DeleteMapping("/items/{itemId}/images/{imageId}")
+    @Override
+    public ApiResult<?> deleteImage(
+            @PathVariable Long itemId,
+            @PathVariable Long imageId
+    ) {
+        adminItemService.deleteImage(itemId, imageId);
+        return ApiResult.success(SuccessType.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
@@ -1,0 +1,260 @@
+package com.example.cowmjucraft.domain.item.controller.admin;
+
+import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageCreateRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemCreateRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemUpdateRequestDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminItemImageOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Item - Admin", description = "물품 관리자 API")
+public interface AdminItemControllerDocs {
+
+    @Operation(
+            summary = "프로젝트 물품 생성",
+            description = "프로젝트에 새로운 물품을 생성합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "물품 생성 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminProjectItemCreateRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "item-create-request",
+                            value = """
+                                    {
+                                      "name": "명지공방 머그컵",
+                                      "description": "캠퍼스 감성을 담은 머그컵입니다.",
+                                      "price": 12000,
+                                      "saleType": "GROUPBUY",
+                                      "status": "OPEN",
+                                      "thumbnailKey": "uploads/items/thumbnail-001.png",
+                                      "targetQty": 100,
+                                      "fundedQty": 0
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "item-create-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 201,
+                                              "message": "성공적으로 생성하였습니다.",
+                                              "data": {
+                                                "id": 1,
+                                                "projectId": 10,
+                                                "name": "명지공방 머그컵",
+                                                "description": "캠퍼스 감성을 담은 머그컵입니다.",
+                                                "price": 12000,
+                                                "saleType": "GROUPBUY",
+                                                "status": "OPEN",
+                                                "thumbnailKey": "uploads/items/thumbnail-001.png",
+                                                "targetQty": 100,
+                                                "fundedQty": 0,
+                                                "achievementRate": 0.0,
+                                                "remainingQty": 100
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<AdminProjectItemResponseDto> createItem(
+            @Parameter(description = "프로젝트 ID", example = "1")
+            Long projectId,
+            @Valid AdminProjectItemCreateRequestDto request
+    );
+
+    @Operation(
+            summary = "프로젝트 물품 수정",
+            description = "물품 정보를 수정합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "물품 수정 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminProjectItemUpdateRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "item-update-request",
+                            value = """
+                                    {
+                                      "name": "명지공방 머그컵",
+                                      "description": "캠퍼스 감성을 담은 머그컵입니다.",
+                                      "price": 11000,
+                                      "saleType": "NORMAL",
+                                      "status": "OPEN",
+                                      "thumbnailKey": "uploads/items/thumbnail-001.png",
+                                      "targetQty": 100,
+                                      "fundedQty": 0
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<AdminProjectItemResponseDto> updateItem(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId,
+            @Valid AdminProjectItemUpdateRequestDto request
+    );
+
+    @Operation(
+            summary = "프로젝트 물품 삭제",
+            description = "물품을 삭제합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류")
+    })
+    ApiResult<?> deleteItem(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId
+    );
+
+    @Operation(
+            summary = "물품 이미지 등록",
+            description = "물품 상세 이미지 목록을 등록합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "이미지 등록 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminItemImageCreateRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "item-image-create-request",
+                            value = """
+                                    {
+                                      "images": [
+                                        { "imageKey": "uploads/items/detail-001.png", "sortOrder": 0 },
+                                        { "imageKey": "uploads/items/detail-002.png", "sortOrder": 1 }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "item-image-create-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "요청에 성공하였습니다.",
+                                              "data": [
+                                                {
+                                                  "id": 5,
+                                                  "imageKey": "uploads/items/detail-001.png",
+                                                  "sortOrder": 0
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<List<ProjectItemImageResponseDto>> addImages(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId,
+            @Valid AdminItemImageCreateRequestDto request
+    );
+
+    @Operation(
+            summary = "물품 이미지 정렬 변경",
+            description = "물품 이미지 정렬 순서를 일괄 변경합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "정렬 변경 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminItemImageOrderPatchRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "item-image-order-request",
+                            value = """
+                                    {
+                                      "imageIds": [30, 12, 15]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<AdminItemImageOrderPatchResponseDto> patchImageOrder(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId,
+            @Valid AdminItemImageOrderPatchRequestDto request
+    );
+
+    @Operation(
+            summary = "물품 이미지 삭제",
+            description = "단일 물품 이미지를 삭제합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류")
+    })
+    ApiResult<?> deleteImage(
+            @Parameter(description = "물품 ID", example = "1")
+            @PathVariable Long itemId,
+            @Parameter(description = "이미지 ID", example = "1")
+            @PathVariable Long imageId
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemController.java
@@ -1,0 +1,37 @@
+package com.example.cowmjucraft.domain.item.controller.client;
+
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemDetailResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemListResponseDto;
+import com.example.cowmjucraft.domain.item.service.ItemService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class ItemController implements ItemControllerDocs {
+
+    private final ItemService itemService;
+
+    @GetMapping("/projects/{projectId}/items")
+    @Override
+    public ApiResult<List<ProjectItemListResponseDto>> getProjectItems(
+            @PathVariable Long projectId
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, itemService.getItems(projectId));
+    }
+
+    @GetMapping("/items/{itemId}")
+    @Override
+    public ApiResult<ProjectItemDetailResponseDto> getItem(
+            @PathVariable Long itemId
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, itemService.getItem(itemId));
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemControllerDocs.java
@@ -1,0 +1,111 @@
+package com.example.cowmjucraft.domain.item.controller.client;
+
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemDetailResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemListResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+
+@Tag(name = "Item - Public", description = "물품 공개 조회 API")
+public interface ItemControllerDocs {
+
+    @Operation(
+            summary = "프로젝트 물품 목록 조회",
+            description = "프로젝트에 연결된 물품 목록을 최신순으로 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "items-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "요청에 성공하였습니다.",
+                                              "data": [
+                                                {
+                                                  "id": 1,
+                                                  "name": "명지공방 머그컵",
+                                                  "price": 12000,
+                                                  "saleType": "GROUPBUY",
+                                                  "status": "OPEN",
+                                                  "thumbnailKey": "uploads/items/thumbnail-001.png",
+                                                  "targetQty": 100,
+                                                  "fundedQty": 40,
+                                                  "achievementRate": 40.0,
+                                                  "remainingQty": 60
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류")
+    })
+    ApiResult<List<ProjectItemListResponseDto>> getProjectItems(
+            @Parameter(description = "프로젝트 ID", example = "1")
+            Long projectId
+    );
+
+    @Operation(
+            summary = "물품 상세 조회",
+            description = "물품 상세 정보 및 상세 이미지 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "item-detail-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "요청에 성공하였습니다.",
+                                              "data": {
+                                                "id": 1,
+                                                "projectId": 10,
+                                                "name": "명지공방 머그컵",
+                                                "description": "캠퍼스 감성을 담은 머그컵입니다.",
+                                                "price": 12000,
+                                                "saleType": "GROUPBUY",
+                                                "status": "OPEN",
+                                                "thumbnailKey": "uploads/items/thumbnail-001.png",
+                                                "images": [
+                                                  {
+                                                    "id": 5,
+                                                    "imageKey": "uploads/items/detail-001.png",
+                                                    "sortOrder": 0
+                                                  }
+                                                ],
+                                                "targetQty": 100,
+                                                "fundedQty": 40,
+                                                "achievementRate": 40.0,
+                                                "remainingQty": 60
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류")
+    })
+    ApiResult<ProjectItemDetailResponseDto> getItem(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminItemImageCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminItemImageCreateRequestDto.java
@@ -1,0 +1,29 @@
+package com.example.cowmjucraft.domain.item.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Min;
+import java.util.List;
+
+@Schema(description = "물품 이미지 등록 요청")
+public record AdminItemImageCreateRequestDto(
+
+        @NotEmpty
+        @Schema(description = "이미지 목록")
+        List<ImageRequestDto> images
+) {
+
+    @Schema(description = "이미지 요청 정보")
+    public record ImageRequestDto(
+
+            @NotBlank
+            @Schema(description = "이미지 S3 key", example = "uploads/items/detail-001.png")
+            String imageKey,
+
+            @Min(0)
+            @Schema(description = "정렬 순서 (0부터 시작)", example = "0")
+            int sortOrder
+    ) {
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminItemImageOrderPatchRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminItemImageOrderPatchRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.cowmjucraft.domain.item.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Schema(description = "물품 이미지 정렬 변경 요청")
+public record AdminItemImageOrderPatchRequestDto(
+
+        @NotEmpty
+        @Schema(description = "정렬 순서를 적용할 이미지 ID 목록", example = "[30, 12, 15]")
+        List<Long> imageIds
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
@@ -1,0 +1,43 @@
+package com.example.cowmjucraft.domain.item.dto.request;
+
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "프로젝트 물품 생성 요청")
+public record AdminProjectItemCreateRequestDto(
+
+        @NotBlank
+        @Schema(description = "물품명", example = "명지공방 머그컵")
+        String name,
+
+        @NotBlank
+        @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
+        String description,
+
+        @Min(0)
+        @Schema(description = "가격", example = "12000")
+        int price,
+
+        @NotNull
+        @Schema(description = "판매 유형", example = "NORMAL")
+        ItemSaleType saleType,
+
+        @NotNull
+        @Schema(description = "상태", example = "OPEN")
+        ItemStatus status,
+
+        @NotBlank
+        @Schema(description = "대표 이미지 S3 key", example = "uploads/items/thumbnail-001.png")
+        String thumbnailKey,
+
+        @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
+        Integer targetQty,
+
+        @Schema(description = "현재 모금 수량 (미입력 시 0)", example = "0")
+        Integer fundedQty
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
@@ -1,0 +1,44 @@
+package com.example.cowmjucraft.domain.item.dto.request;
+
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "프로젝트 물품 수정 요청")
+public record AdminProjectItemUpdateRequestDto(
+
+        @NotBlank
+        @Schema(description = "물품명", example = "명지공방 머그컵")
+        String name,
+
+        @NotBlank
+        @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
+        String description,
+
+        @Min(0)
+        @Schema(description = "가격", example = "12000")
+        int price,
+
+        @NotNull
+        @Schema(description = "판매 유형", example = "NORMAL")
+        ItemSaleType saleType,
+
+        @NotNull
+        @Schema(description = "상태", example = "OPEN")
+        ItemStatus status,
+
+        @NotBlank
+        @Schema(description = "대표 이미지 S3 key", example = "uploads/items/thumbnail-001.png")
+        String thumbnailKey,
+
+        @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
+        Integer targetQty,
+
+        @NotNull
+        @Schema(description = "현재 모금 수량", example = "0")
+        Integer fundedQty
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminItemImageOrderPatchResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminItemImageOrderPatchResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.cowmjucraft.domain.item.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "물품 이미지 정렬 변경 응답")
+public record AdminItemImageOrderPatchResponseDto(
+
+        @Schema(description = "물품 ID", example = "10")
+        Long itemId,
+
+        @Schema(description = "변경된 이미지 개수", example = "3")
+        int updatedCount
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemResponseDto.java
@@ -1,0 +1,58 @@
+package com.example.cowmjucraft.domain.item.dto.response;
+
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "프로젝트 물품 관리자 응답")
+public record AdminProjectItemResponseDto(
+
+        @Schema(description = "물품 ID", example = "1")
+        Long id,
+
+        @Schema(description = "프로젝트 ID", example = "10")
+        Long projectId,
+
+        @Schema(description = "물품명", example = "명지공방 머그컵")
+        String name,
+
+        @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
+        String description,
+
+        @Schema(description = "가격", example = "12000")
+        int price,
+
+        @Schema(description = "판매 유형", example = "GROUPBUY")
+        ItemSaleType saleType,
+
+        @Schema(description = "상태", example = "OPEN")
+        ItemStatus status,
+
+        @Schema(description = "대표 이미지 S3 key", example = "uploads/items/thumbnail-001.png")
+        String thumbnailKey,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
+        Integer targetQty,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "현재 모금 수량 (GROUPBUY 전용)", example = "40")
+        Integer fundedQty,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "달성률(%) (GROUPBUY 전용)", example = "40.0")
+        Double achievementRate,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "남은 수량 (GROUPBUY 전용)", example = "60")
+        Integer remainingQty,
+
+        @Schema(description = "생성 시각")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정 시각")
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemDetailResponseDto.java
@@ -1,0 +1,55 @@
+package com.example.cowmjucraft.domain.item.dto.response;
+
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "프로젝트 물품 상세 응답")
+public record ProjectItemDetailResponseDto(
+
+        @Schema(description = "물품 ID", example = "1")
+        Long id,
+
+        @Schema(description = "프로젝트 ID", example = "10")
+        Long projectId,
+
+        @Schema(description = "물품명", example = "명지공방 머그컵")
+        String name,
+
+        @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
+        String description,
+
+        @Schema(description = "가격", example = "12000")
+        int price,
+
+        @Schema(description = "판매 유형", example = "GROUPBUY")
+        ItemSaleType saleType,
+
+        @Schema(description = "상태", example = "OPEN")
+        ItemStatus status,
+
+        @Schema(description = "대표 이미지 S3 key", example = "uploads/items/thumbnail-001.png")
+        String thumbnailKey,
+
+        @Schema(description = "상세 이미지 목록")
+        List<ProjectItemImageResponseDto> images,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
+        Integer targetQty,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "현재 모금 수량 (GROUPBUY 전용)", example = "40")
+        Integer fundedQty,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "달성률(%) (GROUPBUY 전용)", example = "40.0")
+        Double achievementRate,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "남은 수량 (GROUPBUY 전용)", example = "60")
+        Integer remainingQty
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemImageResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemImageResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.cowmjucraft.domain.item.dto.response;
+
+import com.example.cowmjucraft.domain.item.entity.ItemImage;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "물품 이미지 응답")
+public record ProjectItemImageResponseDto(
+
+        @Schema(description = "이미지 ID", example = "10")
+        Long id,
+
+        @Schema(description = "이미지 S3 key", example = "uploads/items/detail-001.png")
+        String imageKey,
+
+        @Schema(description = "정렬 순서", example = "0")
+        int sortOrder
+) {
+    public static ProjectItemImageResponseDto from(ItemImage image) {
+        return new ProjectItemImageResponseDto(
+                image.getId(),
+                image.getImageKey(),
+                image.getSortOrder()
+        );
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemListResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemListResponseDto.java
@@ -1,0 +1,45 @@
+package com.example.cowmjucraft.domain.item.dto.response;
+
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로젝트 물품 목록 응답")
+public record ProjectItemListResponseDto(
+
+        @Schema(description = "물품 ID", example = "1")
+        Long id,
+
+        @Schema(description = "물품명", example = "명지공방 머그컵")
+        String name,
+
+        @Schema(description = "가격", example = "12000")
+        int price,
+
+        @Schema(description = "판매 유형", example = "NORMAL")
+        ItemSaleType saleType,
+
+        @Schema(description = "상태", example = "OPEN")
+        ItemStatus status,
+
+        @Schema(description = "대표 이미지 S3 key", example = "uploads/items/thumbnail-001.png")
+        String thumbnailKey,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
+        Integer targetQty,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "현재 모금 수량 (GROUPBUY 전용)", example = "40")
+        Integer fundedQty,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "달성률(%) (GROUPBUY 전용)", example = "40.0")
+        Double achievementRate,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "남은 수량 (GROUPBUY 전용)", example = "60")
+        Integer remainingQty
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ItemImage.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ItemImage.java
@@ -1,0 +1,46 @@
+package com.example.cowmjucraft.domain.item.entity;
+
+import com.example.cowmjucraft.domain.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "item_images")
+public class ItemImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private ProjectItem item;
+
+    @Column(length = 255, nullable = false)
+    private String imageKey;
+
+    @Column(nullable = false)
+    private int sortOrder;
+
+    public ItemImage(ProjectItem item, String imageKey, int sortOrder) {
+        this.item = item;
+        this.imageKey = imageKey;
+        this.sortOrder = sortOrder;
+    }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ItemSaleType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ItemSaleType.java
@@ -1,0 +1,6 @@
+package com.example.cowmjucraft.domain.item.entity;
+
+public enum ItemSaleType {
+    NORMAL,
+    GROUPBUY
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ItemStatus.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ItemStatus.java
@@ -1,0 +1,7 @@
+package com.example.cowmjucraft.domain.item.entity;
+
+public enum ItemStatus {
+    PREPARING,
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
@@ -1,0 +1,103 @@
+package com.example.cowmjucraft.domain.item.entity;
+
+import com.example.cowmjucraft.domain.common.BaseTimeEntity;
+import com.example.cowmjucraft.domain.project.entity.Project;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "project_items")
+public class ProjectItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Lob
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ItemSaleType saleType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ItemStatus status;
+
+    @Column(length = 255, nullable = false)
+    private String thumbnailKey;
+
+    @Column(name = "target_qty")
+    private Integer targetQty;
+
+    @Column(name = "funded_qty", nullable = false)
+    private int fundedQty;
+
+    public ProjectItem(
+            Project project,
+            String name,
+            String description,
+            int price,
+            ItemSaleType saleType,
+            ItemStatus status,
+            String thumbnailKey,
+            Integer targetQty,
+            int fundedQty
+    ) {
+        this.project = project;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.saleType = saleType;
+        this.status = status;
+        this.thumbnailKey = thumbnailKey;
+        this.targetQty = targetQty;
+        this.fundedQty = fundedQty;
+    }
+
+    public void update(
+            String name,
+            String description,
+            int price,
+            ItemSaleType saleType,
+            ItemStatus status,
+            String thumbnailKey,
+            Integer targetQty,
+            int fundedQty
+    ) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.saleType = saleType;
+        this.status = status;
+        this.thumbnailKey = thumbnailKey;
+        this.targetQty = targetQty;
+        this.fundedQty = fundedQty;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/repository/ItemImageRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/repository/ItemImageRepository.java
@@ -1,0 +1,12 @@
+package com.example.cowmjucraft.domain.item.repository;
+
+import com.example.cowmjucraft.domain.item.entity.ItemImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
+
+    List<ItemImage> findByItemIdOrderBySortOrderAsc(Long itemId);
+
+    long countByItemId(Long itemId);
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/repository/ProjectItemRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/repository/ProjectItemRepository.java
@@ -1,0 +1,10 @@
+package com.example.cowmjucraft.domain.item.repository;
+
+import com.example.cowmjucraft.domain.item.entity.ProjectItem;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectItemRepository extends JpaRepository<ProjectItem, Long> {
+
+    List<ProjectItem> findByProjectIdOrderByCreatedAtDescIdDesc(Long projectId);
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
@@ -1,0 +1,257 @@
+package com.example.cowmjucraft.domain.item.service;
+
+import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageCreateRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemCreateRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemUpdateRequestDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminItemImageOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
+import com.example.cowmjucraft.domain.item.entity.ItemImage;
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ProjectItem;
+import com.example.cowmjucraft.domain.item.repository.ItemImageRepository;
+import com.example.cowmjucraft.domain.item.repository.ProjectItemRepository;
+import com.example.cowmjucraft.domain.project.entity.Project;
+import com.example.cowmjucraft.domain.project.repository.ProjectRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class AdminItemService {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectItemRepository projectItemRepository;
+    private final ItemImageRepository itemImageRepository;
+
+    @Transactional
+    public AdminProjectItemResponseDto create(Long projectId, AdminProjectItemCreateRequestDto request) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("project not found"));
+
+        NormalizedItemRequest normalized = normalizeCreate(request);
+        ProjectItem item = new ProjectItem(
+                project,
+                request.name(),
+                request.description(),
+                request.price(),
+                request.saleType(),
+                request.status(),
+                request.thumbnailKey(),
+                normalized.targetQty(),
+                normalized.fundedQty()
+        );
+        ProjectItem saved = projectItemRepository.save(item);
+        return toAdminResponse(saved);
+    }
+
+    @Transactional
+    public AdminProjectItemResponseDto update(Long itemId, AdminProjectItemUpdateRequestDto request) {
+        ProjectItem item = projectItemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("item not found"));
+
+        NormalizedItemRequest normalized = normalizeUpdate(request);
+        item.update(
+                request.name(),
+                request.description(),
+                request.price(),
+                request.saleType(),
+                request.status(),
+                request.thumbnailKey(),
+                normalized.targetQty(),
+                normalized.fundedQty()
+        );
+        return toAdminResponse(item);
+    }
+
+    @Transactional
+    public void delete(Long itemId) {
+        ProjectItem item = projectItemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("item not found"));
+        projectItemRepository.delete(item);
+    }
+
+    @Transactional
+    public List<ProjectItemImageResponseDto> addImages(Long itemId, AdminItemImageCreateRequestDto request) {
+        ProjectItem item = projectItemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("item not found"));
+
+        List<AdminItemImageCreateRequestDto.ImageRequestDto> images = request.images();
+        if (images == null || images.isEmpty()) {
+            throw new IllegalArgumentException("images are required");
+        }
+
+        Set<Integer> sortOrders = new HashSet<>();
+        for (AdminItemImageCreateRequestDto.ImageRequestDto image : images) {
+            if (!sortOrders.add(image.sortOrder())) {
+                throw new IllegalArgumentException("duplicate sortOrder: " + image.sortOrder());
+            }
+            if (image.sortOrder() < 0) {
+                throw new IllegalArgumentException("sortOrder must be >= 0");
+            }
+        }
+
+        Set<Integer> existingOrders = itemImageRepository.findByItemIdOrderBySortOrderAsc(itemId).stream()
+                .map(ItemImage::getSortOrder)
+                .collect(Collectors.toSet());
+        for (Integer order : sortOrders) {
+            if (existingOrders.contains(order)) {
+                throw new IllegalArgumentException("sortOrder already exists: " + order);
+            }
+        }
+
+        List<ItemImage> entities = images.stream()
+                .map(image -> new ItemImage(item, image.imageKey(), image.sortOrder()))
+                .toList();
+
+        return itemImageRepository.saveAll(entities).stream()
+                .map(ProjectItemImageResponseDto::from)
+                .toList();
+    }
+
+    @Transactional
+    public AdminItemImageOrderPatchResponseDto patchImageOrder(
+            Long itemId,
+            AdminItemImageOrderPatchRequestDto request
+    ) {
+        ProjectItem item = projectItemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("item not found"));
+
+        List<Long> imageIds = request.imageIds();
+        if (imageIds == null || imageIds.isEmpty()) {
+            throw new IllegalArgumentException("imageIds are required");
+        }
+
+        Set<Long> uniqueIds = new HashSet<>();
+        for (Long id : imageIds) {
+            if (!uniqueIds.add(id)) {
+                throw new IllegalArgumentException("duplicate imageId: " + id);
+            }
+        }
+
+        long totalCount = itemImageRepository.countByItemId(itemId);
+        if (totalCount != imageIds.size()) {
+            throw new IllegalArgumentException("imageIds size must match item images");
+        }
+
+        List<ItemImage> images = itemImageRepository.findAllById(imageIds);
+        if (images.size() != imageIds.size()) {
+            throw new IllegalArgumentException("some imageIds not found");
+        }
+
+        Map<Long, ItemImage> imageMap = images.stream()
+                .collect(Collectors.toMap(ItemImage::getId, Function.identity()));
+
+        int sortOrder = 0;
+        for (Long imageId : imageIds) {
+            ItemImage image = imageMap.get(imageId);
+            if (!image.getItem().getId().equals(item.getId())) {
+                throw new IllegalArgumentException("imageId does not belong to item: " + imageId);
+            }
+            image.updateSortOrder(sortOrder++);
+        }
+
+        return new AdminItemImageOrderPatchResponseDto(itemId, imageIds.size());
+    }
+
+    @Transactional
+    public void deleteImage(Long itemId, Long imageId) {
+        ItemImage image = itemImageRepository.findById(imageId)
+                .orElseThrow(() -> new IllegalArgumentException("item image not found"));
+        if (!image.getItem().getId().equals(itemId)) {
+            throw new IllegalArgumentException("imageId does not belong to item");
+        }
+        itemImageRepository.delete(image);
+    }
+
+    private NormalizedItemRequest normalizeCreate(AdminProjectItemCreateRequestDto request) {
+        return normalize(
+                request.saleType(),
+                request.targetQty(),
+                request.fundedQty()
+        );
+    }
+
+    private NormalizedItemRequest normalizeUpdate(AdminProjectItemUpdateRequestDto request) {
+        return normalize(
+                request.saleType(),
+                request.targetQty(),
+                request.fundedQty()
+        );
+    }
+
+    private NormalizedItemRequest normalize(
+            ItemSaleType saleType,
+            Integer targetQty,
+            Integer fundedQty
+    ) {
+        int normalizedFundedQty = fundedQty == null ? 0 : fundedQty;
+        if (normalizedFundedQty < 0) {
+            throw new IllegalArgumentException("fundedQty must be >= 0");
+        }
+
+        Integer normalizedTargetQty = targetQty;
+        if (saleType == ItemSaleType.GROUPBUY) {
+            if (normalizedTargetQty == null || normalizedTargetQty < 1) {
+                throw new IllegalArgumentException("targetQty must be >= 1 for GROUPBUY");
+            }
+        } else {
+            normalizedTargetQty = null;
+        }
+
+        return new NormalizedItemRequest(normalizedTargetQty, normalizedFundedQty);
+    }
+
+    private AdminProjectItemResponseDto toAdminResponse(ProjectItem item) {
+        GroupbuyInfo info = calculateGroupbuyInfo(item);
+        return new AdminProjectItemResponseDto(
+                item.getId(),
+                item.getProject().getId(),
+                item.getName(),
+                item.getDescription(),
+                item.getPrice(),
+                item.getSaleType(),
+                item.getStatus(),
+                item.getThumbnailKey(),
+                info.targetQty(),
+                info.fundedQty(),
+                info.achievementRate(),
+                info.remainingQty(),
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
+
+    private GroupbuyInfo calculateGroupbuyInfo(ProjectItem item) {
+        if (item.getSaleType() != ItemSaleType.GROUPBUY) {
+            return new GroupbuyInfo(null, null, null, null);
+        }
+        Integer targetQty = item.getTargetQty();
+        int fundedQty = item.getFundedQty();
+        double rate = 0.0;
+        if (targetQty != null && targetQty > 0) {
+            rate = (double) fundedQty / targetQty * 100.0;
+        }
+        int remainingQty = targetQty == null ? 0 : Math.max(targetQty - fundedQty, 0);
+        return new GroupbuyInfo(targetQty, fundedQty, rate, remainingQty);
+    }
+
+    private record NormalizedItemRequest(Integer targetQty, int fundedQty) {
+    }
+
+    private record GroupbuyInfo(
+            Integer targetQty,
+            Integer fundedQty,
+            Double achievementRate,
+            Integer remainingQty
+    ) {
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/service/ItemService.java
@@ -1,0 +1,108 @@
+package com.example.cowmjucraft.domain.item.service;
+
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemDetailResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemListResponseDto;
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ProjectItem;
+import com.example.cowmjucraft.domain.item.repository.ItemImageRepository;
+import com.example.cowmjucraft.domain.item.repository.ProjectItemRepository;
+import com.example.cowmjucraft.domain.project.entity.Project;
+import com.example.cowmjucraft.domain.project.repository.ProjectRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ItemService {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectItemRepository projectItemRepository;
+    private final ItemImageRepository itemImageRepository;
+
+    @Transactional(readOnly = true)
+    public List<ProjectItemListResponseDto> getItems(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("project not found"));
+
+        List<ProjectItem> items = projectItemRepository.findByProjectIdOrderByCreatedAtDescIdDesc(project.getId());
+        return items.stream()
+                .map(this::toListResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectItemDetailResponseDto getItem(Long itemId) {
+        ProjectItem item = projectItemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("item not found"));
+
+        List<ProjectItemImageResponseDto> images = itemImageRepository.findByItemIdOrderBySortOrderAsc(itemId)
+                .stream()
+                .map(ProjectItemImageResponseDto::from)
+                .toList();
+
+        return toDetailResponse(item, images);
+    }
+
+    private ProjectItemListResponseDto toListResponse(ProjectItem item) {
+        GroupbuyInfo info = calculateGroupbuyInfo(item);
+        return new ProjectItemListResponseDto(
+                item.getId(),
+                item.getName(),
+                item.getPrice(),
+                item.getSaleType(),
+                item.getStatus(),
+                item.getThumbnailKey(),
+                info.targetQty(),
+                info.fundedQty(),
+                info.achievementRate(),
+                info.remainingQty()
+        );
+    }
+
+    private ProjectItemDetailResponseDto toDetailResponse(
+            ProjectItem item,
+            List<ProjectItemImageResponseDto> images
+    ) {
+        GroupbuyInfo info = calculateGroupbuyInfo(item);
+        return new ProjectItemDetailResponseDto(
+                item.getId(),
+                item.getProject().getId(),
+                item.getName(),
+                item.getDescription(),
+                item.getPrice(),
+                item.getSaleType(),
+                item.getStatus(),
+                item.getThumbnailKey(),
+                images,
+                info.targetQty(),
+                info.fundedQty(),
+                info.achievementRate(),
+                info.remainingQty()
+        );
+    }
+
+    private GroupbuyInfo calculateGroupbuyInfo(ProjectItem item) {
+        if (item.getSaleType() != ItemSaleType.GROUPBUY) {
+            return new GroupbuyInfo(null, null, null, null);
+        }
+        Integer targetQty = item.getTargetQty();
+        int fundedQty = item.getFundedQty();
+        double rate = 0.0;
+        if (targetQty != null && targetQty > 0) {
+            rate = (double) fundedQty / targetQty * 100.0;
+        }
+        int remainingQty = targetQty == null ? 0 : Math.max(targetQty - fundedQty, 0);
+        return new GroupbuyInfo(targetQty, fundedQty, rate, remainingQty);
+    }
+
+    private record GroupbuyInfo(
+            Integer targetQty,
+            Integer fundedQty,
+            Double achievementRate,
+            Integer remainingQty
+    ) {
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/cowmjucraft/global/exception/GlobalExceptionHandler.java
@@ -31,7 +31,7 @@ public class GlobalExceptionHandler {
 
         String detail = buildFieldErrorDetail(bindingResult);
         String message = buildValidationMessage(detail);
-        return errorResponse(ErrorType.INVALID_REQUEST, message);
+        return errorResponse(ErrorType.VALIDATION_FAILED, message);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
@@ -43,7 +43,7 @@ public class GlobalExceptionHandler {
         }
         String detail = summarizeDetails(details);
         String message = buildValidationMessage(detail);
-        return errorResponse(ErrorType.INVALID_REQUEST, message);
+        return errorResponse(ErrorType.VALIDATION_FAILED, message);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)


### PR DESCRIPTION
# 요약

프로젝트에 속한 물품(Item) 도메인과 물품 이미지(ItemImage) 관리 기능을 구현했습니다.  
관리자용 물품 CRUD, 물품 이미지 등록/정렬/삭제 API와  
사용자용 물품 목록 및 상세 조회 API를 추가했습니다.

# 작업 내용

- [x] 프로젝트 물품(Item) 도메인 구현
  - 물품 생성 / 수정 / 삭제 관리자 API
  - 프로젝트별 물품 목록 조회, 물품 상세 조회 Public API
  - 판매 유형(NORMAL / GROUPBUY) 및 상태 관리
  - 공동구매 정보(targetQty, fundedQty, 달성률, 남은 수량) 계산 로직 적용

- [x] 물품 이미지(ItemImage) 관리 기능 구현
  - 물품 상세 이미지 다중 등록
  - 이미지 정렬 순서 변경(드래그앤드롭 대응)
  - 단일 이미지 삭제
  - 이미지 정렬 및 소속 검증 로직 추가

# 기타 (논의하고 싶은 부분)

- Media 도메인 구조 및 MediaUsageType 설계는 추후 리팩토링 예정
- 주문/결제 연동 시 fundedQty 자동 증가 로직 분리 필요

# 타 직군 전달 사항

- 물품/이미지 순서 변경은 즉시 반영되지 않으며, 저장 API 호출 시 적용됩니다.
- 이미지 업로드는 Media presign PUT API를 통해 S3에 업로드 후 key만 전달하면 됩니다.