### PR TITLE
feat: 공지사항 기능 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/media/policy/MediaUsageType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/media/policy/MediaUsageType.java
@@ -6,5 +6,6 @@ public enum MediaUsageType {
     PROJECT,
     LOGO,
     JOURNAL,
+    NOTICE,
     ETC
 }

--- a/src/main/java/com/example/cowmjucraft/domain/notice/controller/admin/AdminNoticeController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/controller/admin/AdminNoticeController.java
@@ -1,0 +1,68 @@
+package com.example.cowmjucraft.domain.notice.controller.admin;
+
+import com.example.cowmjucraft.domain.notice.dto.request.AdminNoticeCreateRequestDto;
+import com.example.cowmjucraft.domain.notice.dto.request.AdminNoticeUpdateRequestDto;
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeDetailResponseDto;
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeSummaryResponseDto;
+import com.example.cowmjucraft.domain.notice.service.AdminNoticeService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/admin/notices")
+public class AdminNoticeController implements AdminNoticeControllerDocs {
+
+    private final AdminNoticeService adminNoticeService;
+
+    @PostMapping
+    @Override
+    public ApiResult<NoticeDetailResponseDto> createNotice(
+            @Valid @RequestBody AdminNoticeCreateRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.CREATED, adminNoticeService.create(request));
+    }
+
+    @PutMapping("/{noticeId}")
+    @Override
+    public ApiResult<NoticeDetailResponseDto> updateNotice(
+            @PathVariable Long noticeId,
+            @Valid @RequestBody AdminNoticeUpdateRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminNoticeService.update(noticeId, request));
+    }
+
+    @DeleteMapping("/{noticeId}")
+    @Override
+    public ApiResult<?> deleteNotice(
+            @PathVariable Long noticeId
+    ) {
+        adminNoticeService.delete(noticeId);
+        return ApiResult.success(SuccessType.NO_CONTENT);
+    }
+
+    @GetMapping
+    @Override
+    public ApiResult<List<NoticeSummaryResponseDto>> getNotices() {
+        return ApiResult.success(SuccessType.SUCCESS, adminNoticeService.getNotices());
+    }
+
+    @GetMapping("/{noticeId}")
+    @Override
+    public ApiResult<NoticeDetailResponseDto> getNotice(
+            @PathVariable Long noticeId
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminNoticeService.getNotice(noticeId));
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/controller/admin/AdminNoticeControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/controller/admin/AdminNoticeControllerDocs.java
@@ -1,0 +1,123 @@
+package com.example.cowmjucraft.domain.notice.controller.admin;
+
+import com.example.cowmjucraft.domain.notice.dto.request.AdminNoticeCreateRequestDto;
+import com.example.cowmjucraft.domain.notice.dto.request.AdminNoticeUpdateRequestDto;
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeDetailResponseDto;
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeSummaryResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+
+@Tag(name = "Notice - Admin", description = "공지사항 관리자 API")
+public interface AdminNoticeControllerDocs {
+
+    @Operation(summary = "공지사항 생성", description = "공지사항을 생성합니다.")
+    @RequestBody(
+            required = true,
+            description = "공지사항 생성 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminNoticeCreateRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "notice-create-request",
+                            value = """
+                                    {
+                                      "title": "설 연휴 배송 일정 안내",
+                                      "content": "설 연휴 기간 동안 배송이 중단됩니다.",
+                                      "imageKeys": ["uploads/notices/notice-001.png"]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<NoticeDetailResponseDto> createNotice(
+            @Valid AdminNoticeCreateRequestDto request
+    );
+
+    @Operation(summary = "공지사항 수정", description = "공지사항을 수정합니다.")
+    @RequestBody(
+            required = true,
+            description = "공지사항 수정 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminNoticeUpdateRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "notice-update-request",
+                            value = """
+                                    {
+                                      "title": "설 연휴 배송 일정 안내 (수정)",
+                                      "content": "설 연휴 기간 동안 배송이 중단됩니다.",
+                                      "imageKeys": ["uploads/notices/notice-001.png"]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<NoticeDetailResponseDto> updateNotice(
+            @Parameter(description = "공지 ID", example = "1")
+            Long noticeId,
+            @Valid AdminNoticeUpdateRequestDto request
+    );
+
+    @Operation(summary = "공지사항 삭제", description = "공지사항을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
+    })
+    ApiResult<?> deleteNotice(
+            @Parameter(description = "공지 ID", example = "1")
+            Long noticeId
+    );
+
+    @Operation(summary = "공지사항 목록 조회", description = "공지사항 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            )
+    })
+    ApiResult<List<NoticeSummaryResponseDto>> getNotices();
+
+    @Operation(summary = "공지사항 상세 조회", description = "공지사항 상세를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
+    })
+    ApiResult<NoticeDetailResponseDto> getNotice(
+            @Parameter(description = "공지 ID", example = "1")
+            Long noticeId
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/controller/client/NoticeController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/controller/client/NoticeController.java
@@ -1,0 +1,35 @@
+package com.example.cowmjucraft.domain.notice.controller.client;
+
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeDetailResponseDto;
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeSummaryResponseDto;
+import com.example.cowmjucraft.domain.notice.service.NoticeService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/notices")
+public class NoticeController implements NoticeControllerDocs {
+
+    private final NoticeService noticeService;
+
+    @GetMapping
+    @Override
+    public ApiResult<List<NoticeSummaryResponseDto>> getNotices() {
+        return ApiResult.success(SuccessType.SUCCESS, noticeService.getNotices());
+    }
+
+    @GetMapping("/{noticeId}")
+    @Override
+    public ApiResult<NoticeDetailResponseDto> getNotice(
+            @PathVariable Long noticeId
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, noticeService.getNotice(noticeId));
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/controller/client/NoticeControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/controller/client/NoticeControllerDocs.java
@@ -1,0 +1,41 @@
+package com.example.cowmjucraft.domain.notice.controller.client;
+
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeDetailResponseDto;
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeSummaryResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+
+@Tag(name = "Notice", description = "공지사항 조회 API")
+public interface NoticeControllerDocs {
+
+    @Operation(summary = "공지사항 목록 조회", description = "공지사항 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            )
+    })
+    ApiResult<List<NoticeSummaryResponseDto>> getNotices();
+
+    @Operation(summary = "공지사항 상세 조회", description = "공지사항 상세를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
+    })
+    ApiResult<NoticeDetailResponseDto> getNotice(
+            @Parameter(description = "공지 ID", example = "1")
+            Long noticeId
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/dto/request/AdminNoticeCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/dto/request/AdminNoticeCreateRequestDto.java
@@ -1,0 +1,23 @@
+package com.example.cowmjucraft.domain.notice.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Schema(description = "공지사항 생성 요청")
+public record AdminNoticeCreateRequestDto(
+
+        @NotBlank
+        @Size(max = 100)
+        @Schema(description = "공지 제목", example = "설 연휴 배송 일정 안내")
+        String title,
+
+        @NotBlank
+        @Schema(description = "공지 내용", example = "설 연휴 기간 동안 배송이 중단됩니다.")
+        String content,
+
+        @Schema(description = "공지 이미지 S3 key 목록", example = "[\"uploads/notices/notice-001.png\"]")
+        List<@NotBlank @Size(max = 255) String> imageKeys
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/dto/request/AdminNoticeUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/dto/request/AdminNoticeUpdateRequestDto.java
@@ -1,0 +1,23 @@
+package com.example.cowmjucraft.domain.notice.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Schema(description = "공지사항 수정 요청")
+public record AdminNoticeUpdateRequestDto(
+
+        @NotBlank
+        @Size(max = 100)
+        @Schema(description = "공지 제목", example = "설 연휴 배송 일정 안내")
+        String title,
+
+        @NotBlank
+        @Schema(description = "공지 내용", example = "설 연휴 기간 동안 배송이 중단됩니다.")
+        String content,
+
+        @Schema(description = "공지 이미지 S3 key 목록", example = "[\"uploads/notices/notice-001.png\"]")
+        List<@NotBlank @Size(max = 255) String> imageKeys
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/dto/response/NoticeDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/dto/response/NoticeDetailResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.cowmjucraft.domain.notice.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "공지사항 상세 응답")
+public record NoticeDetailResponseDto(
+
+        @Schema(description = "공지 ID", example = "1")
+        Long id,
+
+        @Schema(description = "공지 제목", example = "설 연휴 배송 일정 안내")
+        String title,
+
+        @Schema(description = "공지 내용", example = "설 연휴 기간 동안 배송이 중단됩니다.")
+        String content,
+
+        @Schema(description = "공지 이미지 S3 key 목록", example = "[\"uploads/notices/notice-001.png\"]")
+        List<String> imageKeys,
+
+        @Schema(description = "등록일시", example = "2026-01-20T10:15:30")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일시", example = "2026-01-22T09:00:00")
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/dto/response/NoticeSummaryResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/dto/response/NoticeSummaryResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.cowmjucraft.domain.notice.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "공지사항 목록 아이템 응답")
+public record NoticeSummaryResponseDto(
+
+        @Schema(description = "공지 ID", example = "1")
+        Long id,
+
+        @Schema(description = "공지 제목", example = "설 연휴 배송 일정 안내")
+        String title,
+
+        @Schema(description = "공지 이미지 S3 key 목록", example = "[\"uploads/notices/notice-001.png\"]")
+        List<String> imageKeys,
+
+        @Schema(description = "등록일시", example = "2026-01-20T10:15:30")
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/entity/Notice.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/entity/Notice.java
@@ -1,0 +1,64 @@
+package com.example.cowmjucraft.domain.notice.entity;
+
+import com.example.cowmjucraft.domain.common.BaseTimeEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "notices")
+public class Notice extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "notice_images", joinColumns = @JoinColumn(name = "notice_id"))
+    @OrderColumn(name = "sort_order")
+    @Column(name = "image_key", length = 255)
+    private List<String> imageKeys = new ArrayList<>();
+
+    public Notice(String title, String content, List<String> imageKeys) {
+        this.title = title;
+        this.content = content;
+        this.imageKeys = normalizeImageKeys(imageKeys);
+    }
+
+    public void update(String title, String content, List<String> imageKeys) {
+        this.title = title;
+        this.content = content;
+        this.imageKeys.clear();
+        this.imageKeys.addAll(normalizeImageKeys(imageKeys));
+    }
+
+    private List<String> normalizeImageKeys(List<String> imageKeys) {
+        if (imageKeys == null) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(imageKeys);
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,10 @@
+package com.example.cowmjucraft.domain.notice.repository;
+
+import com.example.cowmjucraft.domain.notice.entity.Notice;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    List<Notice> findAllByOrderByCreatedAtDesc();
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/service/AdminNoticeService.java
@@ -1,0 +1,80 @@
+package com.example.cowmjucraft.domain.notice.service;
+
+import com.example.cowmjucraft.domain.notice.dto.request.AdminNoticeCreateRequestDto;
+import com.example.cowmjucraft.domain.notice.dto.request.AdminNoticeUpdateRequestDto;
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeDetailResponseDto;
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeSummaryResponseDto;
+import com.example.cowmjucraft.domain.notice.entity.Notice;
+import com.example.cowmjucraft.domain.notice.repository.NoticeRepository;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class AdminNoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    public AdminNoticeService(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+    @Transactional
+    public NoticeDetailResponseDto create(AdminNoticeCreateRequestDto request) {
+        Notice notice = new Notice(request.title(), request.content(), request.imageKeys());
+        Notice saved = noticeRepository.save(notice);
+        return toDetailResponse(saved);
+    }
+
+    @Transactional
+    public NoticeDetailResponseDto update(Long noticeId, AdminNoticeUpdateRequestDto request) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "notice not found"));
+        notice.update(request.title(), request.content(), request.imageKeys());
+        return toDetailResponse(notice);
+    }
+
+    @Transactional
+    public void delete(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "notice not found"));
+        noticeRepository.delete(notice);
+    }
+
+    @Transactional(readOnly = true)
+    public List<NoticeSummaryResponseDto> getNotices() {
+        return noticeRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(this::toSummaryResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeDetailResponseDto getNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "notice not found"));
+        return toDetailResponse(notice);
+    }
+
+    private NoticeSummaryResponseDto toSummaryResponse(Notice notice) {
+        return new NoticeSummaryResponseDto(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getImageKeys(),
+                notice.getCreatedAt()
+        );
+    }
+
+    private NoticeDetailResponseDto toDetailResponse(Notice notice) {
+        return new NoticeDetailResponseDto(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getImageKeys(),
+                notice.getCreatedAt(),
+                notice.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/service/NoticeService.java
@@ -1,0 +1,56 @@
+package com.example.cowmjucraft.domain.notice.service;
+
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeDetailResponseDto;
+import com.example.cowmjucraft.domain.notice.dto.response.NoticeSummaryResponseDto;
+import com.example.cowmjucraft.domain.notice.entity.Notice;
+import com.example.cowmjucraft.domain.notice.repository.NoticeRepository;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    public NoticeService(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<NoticeSummaryResponseDto> getNotices() {
+        return noticeRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(this::toSummaryResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeDetailResponseDto getNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "notice not found"));
+        return toDetailResponse(notice);
+    }
+
+    private NoticeSummaryResponseDto toSummaryResponse(Notice notice) {
+        return new NoticeSummaryResponseDto(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getImageKeys(),
+                notice.getCreatedAt()
+        );
+    }
+
+    private NoticeDetailResponseDto toDetailResponse(Notice notice) {
+        return new NoticeDetailResponseDto(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getImageKeys(),
+                notice.getCreatedAt(),
+                notice.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/cloud/S3PresignService.java
+++ b/src/main/java/com/example/cowmjucraft/global/cloud/S3PresignService.java
@@ -70,6 +70,7 @@ public class S3PresignService {
             case PROJECT -> "uploads/projects/";
             case LOGO -> "uploads/logos/";
             case JOURNAL -> "uploads/journals/";
+            case NOTICE -> "uploads/notices/";
             case ETC -> "uploads/etc/";
         };
     }


### PR DESCRIPTION
# 요약
공지사항 CRUD 및 조회 API를 추가하고, 공지 이미지 S3 키를 저장할 수 있도록 확장했습니다.

# 작업 내용
- 공지사항 엔티티/레포/서비스/컨트롤러 및 요청, 응답 DTO, Swagger 문서 추가
-  관리자용 등록/수정/삭제/조회 및 사용자용 목록/상세 조회 API 구현 
- Media presign에 NOTICE 타입 추가 및 S3 업로드 경로(uploads/notices/) 확장

# 기타 (논의하고 싶은 부분)
없음

# 타 직군 전달 사항
- 관리자 공지 API: POST/PUT/DELETE/GET /api/admin/notices, GET /api/admin/notices/{noticeId} (Authorization: Bearer 필요) 
- 사용자 공지 API: GET /api/notices, GET /api/notices/{noticeId} 
- 이미지 업로드: POST /api/media/presign-put (usageType=NOTICE), 응답 key를 imageKeys에 저장