### PR TITLE
feat: 마이페이지 관련 기능 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/accounts/user/entity/Member.java
+++ b/src/main/java/com/example/cowmjucraft/domain/accounts/user/entity/Member.java
@@ -21,17 +21,11 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String userId;
-
     @Column(nullable = false)
     private String userName;
 
     @Column(nullable = false, unique = true)
     private String email;
-
-    @Column(nullable = false)
-    private String password;
 
     @Enumerated(EnumType.STRING)
     private SocialProvider provider;
@@ -43,19 +37,12 @@ public class Member {
     @Column(nullable = false)
     private Role role = Role.ROLE_USER;
 
-    public Member(String userId, String userName, String email, String password) {
-        this.userId = userId;
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private MemberAddress address;
+
+    public Member(String userName, String email) {
         this.userName = userName;
         this.email = email;
-        this.password = password;
-    }
-
-    public void updateUserId(String userId) {
-        this.userId = userId;
-    }
-
-    public void updatePassword(String password) {
-        this.password = password;
     }
 
     public void updateUserName(String userName) {
@@ -65,5 +52,22 @@ public class Member {
     public void updateSocial(SocialProvider provider, String providerId) {
         this.provider = provider;
         this.providerId = providerId;
+    }
+
+    public void upsertAddress(
+            String recipientName,
+            String phoneNumber,
+            String postCode,
+            String address
+    ) {
+        if (this.address == null) {
+            this.address = new MemberAddress(this, recipientName, phoneNumber, postCode, address);
+            return;
+        }
+        this.address.update(recipientName, phoneNumber, postCode, address);
+    }
+
+    public void clearAddress() {
+        this.address = null;
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/accounts/user/entity/MemberAddress.java
+++ b/src/main/java/com/example/cowmjucraft/domain/accounts/user/entity/MemberAddress.java
@@ -1,0 +1,59 @@
+package com.example.cowmjucraft.domain.accounts.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "member_addresses")
+public class MemberAddress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
+    private Member member;
+
+    @Column(nullable = false)
+    private String recipientName;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private String postCode;
+
+    @Column(nullable = false)
+    private String address;
+
+    public MemberAddress(
+            Member member,
+            String recipientName,
+            String phoneNumber,
+            String postCode,
+            String address
+    ) {
+        this.member = member;
+        this.recipientName = recipientName;
+        this.phoneNumber = phoneNumber;
+        this.postCode = postCode;
+        this.address = address;
+    }
+
+    public void update(
+            String recipientName,
+            String phoneNumber,
+            String postCode,
+            String address
+    ) {
+        this.recipientName = recipientName;
+        this.phoneNumber = phoneNumber;
+        this.postCode = postCode;
+        this.address = address;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/accounts/user/oauth/controller/UserOAuthControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/accounts/user/oauth/controller/UserOAuthControllerDocs.java
@@ -5,6 +5,7 @@ import com.example.cowmjucraft.domain.accounts.user.oauth.dto.request.NaverLogin
 import com.example.cowmjucraft.domain.accounts.user.oauth.dto.response.UserSocialLoginResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -21,7 +22,24 @@ public interface UserOAuthControllerDocs {
             description = "네이버 OAuth 인가 코드로 로그인 후 JWT를 응답 바디에 반환합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(schema = @Schema(implementation = UserSocialLoginResponseDto.class))),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = UserSocialLoginResponseDto.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "memberId": 1,
+                                              "userName": "홍길동",
+                                              "email": "user@example.com",
+                                              "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 인가 코드")
     })
     ResponseEntity<UserSocialLoginResponseDto> loginWithNaver(@Valid @RequestBody NaverLoginRequestDto request);
@@ -31,7 +49,24 @@ public interface UserOAuthControllerDocs {
             description = "카카오 OAuth 인가 코드로 로그인 후 JWT를 응답 바디에 반환합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(schema = @Schema(implementation = UserSocialLoginResponseDto.class))),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = UserSocialLoginResponseDto.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "memberId": 1,
+                                              "userName": "홍길동",
+                                              "email": "user@example.com",
+                                              "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 인가 코드")
     })
     ResponseEntity<UserSocialLoginResponseDto> loginWithKakao(@Valid @RequestBody KakaoLoginRequestDto request);

--- a/src/main/java/com/example/cowmjucraft/domain/accounts/user/oauth/dto/response/UserSocialLoginResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/accounts/user/oauth/dto/response/UserSocialLoginResponseDto.java
@@ -3,7 +3,8 @@ package com.example.cowmjucraft.domain.accounts.user.oauth.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UserSocialLoginResponseDto(
-        String userId,
+        Long memberId,
+        String userName,
         String email,
         @Schema(description = "Swagger Authorize에 입력할 Access Token (Bearer 제외)")
         String accessToken

--- a/src/main/java/com/example/cowmjucraft/domain/accounts/user/oauth/service/UserOAuthService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/accounts/user/oauth/service/UserOAuthService.java
@@ -11,13 +11,11 @@ import com.example.cowmjucraft.domain.accounts.user.repository.MemberRepository;
 import com.example.cowmjucraft.global.config.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Locale;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Transactional
@@ -27,7 +25,6 @@ public class UserOAuthService {
     private final KakaoOAuthClient kakaoOAuthClient;
     private final NaverOAuthClient naverOAuthClient;
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
     public UserSocialLoginResponseDto loginWithNaver(NaverLoginRequestDto request) {
@@ -53,8 +50,8 @@ public class UserOAuthService {
         Member member = memberRepository.findByProviderAndProviderId(provider, providerId)
                 .orElseGet(() -> createOrLinkMember(provider, providerId, email, nickname));
 
-        String token = jwtTokenProvider.generateMemberToken(member.getUserId());
-        return new UserSocialLoginResponseDto(member.getUserId(), member.getEmail(), token);
+        String token = jwtTokenProvider.generateMemberToken(member.getId());
+        return new UserSocialLoginResponseDto(member.getId(), member.getUserName(), member.getEmail(), token);
     }
 
     private Member createOrLinkMember(
@@ -77,11 +74,11 @@ public class UserOAuthService {
         String safeEmail = (email != null && !email.isBlank())
                 ? email
                 : provider.name().toLowerCase(Locale.ROOT) + "_" + providerId + "@social.local";
-        String userId = provider.name().toLowerCase(Locale.ROOT) + "_" + providerId;
-        String userName = (nickname != null && !nickname.isBlank()) ? nickname : userId;
-        String password = passwordEncoder.encode(UUID.randomUUID().toString());
+        String userName = (nickname != null && !nickname.isBlank())
+                ? nickname
+                : provider.name().toLowerCase(Locale.ROOT) + "_" + providerId;
 
-        Member member = new Member(userId, userName, safeEmail, password);
+        Member member = new Member(userName, safeEmail);
         member.updateSocial(provider, providerId);
         return memberRepository.save(member);
     }

--- a/src/main/java/com/example/cowmjucraft/domain/accounts/user/repository/MemberRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/accounts/user/repository/MemberRepository.java
@@ -7,9 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    boolean existsByUserId(String userId);
-    Optional<Member> findByUserId(String userId);
-
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByProviderAndProviderId(SocialProvider provider, String providerId);

--- a/src/main/java/com/example/cowmjucraft/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,69 @@
+package com.example.cowmjucraft.domain.mypage.controller;
+
+import com.example.cowmjucraft.domain.mypage.dto.request.MyPageAddressRequestDto;
+import com.example.cowmjucraft.domain.mypage.dto.response.MyPageAddressResponseDto;
+import com.example.cowmjucraft.domain.mypage.dto.response.MyPageResponseDto;
+import com.example.cowmjucraft.domain.mypage.service.MyPageService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/mypage")
+public class MyPageController implements MyPageControllerDocs {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    @Override
+    public ApiResult<MyPageResponseDto> getMyPage(
+            @AuthenticationPrincipal String memberId
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, myPageService.getMyPage(parseMemberId(memberId)));
+    }
+
+    @PostMapping("/address")
+    @Override
+    public ApiResult<MyPageAddressResponseDto> createAddress(
+            @AuthenticationPrincipal String memberId,
+            @Valid @RequestBody MyPageAddressRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.CREATED, myPageService.createAddress(parseMemberId(memberId), request));
+    }
+
+    @PutMapping("/address")
+    @Override
+    public ApiResult<MyPageAddressResponseDto> updateAddress(
+            @AuthenticationPrincipal String memberId,
+            @Valid @RequestBody MyPageAddressRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, myPageService.updateAddress(parseMemberId(memberId), request));
+    }
+
+    @DeleteMapping("/address")
+    @Override
+    public ApiResult<?> deleteAddress(
+            @AuthenticationPrincipal String memberId
+    ) {
+        myPageService.deleteAddress(parseMemberId(memberId));
+        return ApiResult.success(SuccessType.NO_CONTENT);
+    }
+
+    private Long parseMemberId(String principal) {
+        try {
+            return Long.valueOf(principal);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid member id");
+        }
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/mypage/controller/MyPageControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/mypage/controller/MyPageControllerDocs.java
@@ -1,0 +1,77 @@
+package com.example.cowmjucraft.domain.mypage.controller;
+
+import com.example.cowmjucraft.domain.mypage.dto.request.MyPageAddressRequestDto;
+import com.example.cowmjucraft.domain.mypage.dto.response.MyPageAddressResponseDto;
+import com.example.cowmjucraft.domain.mypage.dto.response.MyPageResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "MyPage", description = "마이페이지 API")
+public interface MyPageControllerDocs {
+
+    @Operation(summary = "마이페이지 조회", description = "현재 로그인 사용자 정보 및 배송지 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    ApiResult<MyPageResponseDto> getMyPage(
+            @Parameter(hidden = true)
+            String memberId
+    );
+
+    @Operation(summary = "배송지 등록", description = "배송지가 없을 때 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "등록 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "409", description = "이미 배송지 존재")
+    })
+    ApiResult<MyPageAddressResponseDto> createAddress(
+            @Parameter(hidden = true)
+            String memberId,
+            @Valid @RequestBody MyPageAddressRequestDto request
+    );
+
+    @Operation(summary = "배송지 수정", description = "등록된 배송지 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "배송지 없음")
+    })
+    ApiResult<MyPageAddressResponseDto> updateAddress(
+            @Parameter(hidden = true)
+            String memberId,
+            @Valid @RequestBody MyPageAddressRequestDto request
+    );
+
+    @Operation(summary = "배송지 삭제", description = "등록된 배송지를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "삭제 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "배송지 없음")
+    })
+    ApiResult<?> deleteAddress(
+            @Parameter(hidden = true)
+            String memberId
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/mypage/dto/request/MyPageAddressRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/mypage/dto/request/MyPageAddressRequestDto.java
@@ -1,0 +1,23 @@
+package com.example.cowmjucraft.domain.mypage.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record MyPageAddressRequestDto(
+        @Schema(description = "수령인 이름", example = "홍길동")
+        @NotBlank
+        String recipientName,
+
+        @Schema(description = "연락처", example = "01012345678")
+        @NotBlank
+        String phoneNumber,
+
+        @Schema(description = "우편번호", example = "12345")
+        @NotBlank
+        String postCode,
+
+        @Schema(description = "주소", example = "서울특별시 강남구 테헤란로 123")
+        @NotBlank
+        String address
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/mypage/dto/response/MyPageAddressResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/mypage/dto/response/MyPageAddressResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.cowmjucraft.domain.mypage.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyPageAddressResponseDto(
+        @Schema(description = "수령인 이름", example = "홍길동")
+        String recipientName,
+
+        @Schema(description = "연락처", example = "01012345678")
+        String phoneNumber,
+
+        @Schema(description = "우편번호", example = "12345")
+        String postCode,
+
+        @Schema(description = "주소", example = "서울특별시 강남구 테헤란로 123")
+        String address
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/mypage/dto/response/MyPageResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/mypage/dto/response/MyPageResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.cowmjucraft.domain.mypage.dto.response;
+
+import com.example.cowmjucraft.domain.accounts.user.entity.SocialProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyPageResponseDto(
+        @Schema(description = "멤버 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "유저 이름", example = "홍길동")
+        String userName,
+
+        @Schema(description = "이메일", example = "user@example.com")
+        String email,
+
+        @Schema(description = "소셜 로그인 제공자", example = "NAVER", nullable = true)
+        SocialProvider socialProvider,
+
+        @Schema(description = "배송지 정보", nullable = true)
+        MyPageAddressResponseDto address
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/mypage/service/MyPageService.java
@@ -1,0 +1,96 @@
+package com.example.cowmjucraft.domain.mypage.service;
+
+import com.example.cowmjucraft.domain.accounts.user.entity.Member;
+import com.example.cowmjucraft.domain.accounts.user.entity.MemberAddress;
+import com.example.cowmjucraft.domain.accounts.user.entity.SocialProvider;
+import com.example.cowmjucraft.domain.accounts.user.repository.MemberRepository;
+import com.example.cowmjucraft.domain.mypage.dto.request.MyPageAddressRequestDto;
+import com.example.cowmjucraft.domain.mypage.dto.response.MyPageAddressResponseDto;
+import com.example.cowmjucraft.domain.mypage.dto.response.MyPageResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class MyPageService {
+
+    private final MemberRepository memberRepository;
+
+    public MyPageService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public MyPageResponseDto getMyPage(Long memberId) {
+        Member member = getMember(memberId);
+        return toMyPageResponse(member);
+    }
+
+    @Transactional
+    public MyPageAddressResponseDto createAddress(Long memberId, MyPageAddressRequestDto request) {
+        Member member = getMember(memberId);
+        if (member.getAddress() != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "address already exists");
+        }
+        member.upsertAddress(
+                request.recipientName(),
+                request.phoneNumber(),
+                request.postCode(),
+                request.address()
+        );
+        return toAddressResponse(member.getAddress());
+    }
+
+    @Transactional
+    public MyPageAddressResponseDto updateAddress(Long memberId, MyPageAddressRequestDto request) {
+        Member member = getMember(memberId);
+        if (member.getAddress() == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "address not found");
+        }
+        member.upsertAddress(
+                request.recipientName(),
+                request.phoneNumber(),
+                request.postCode(),
+                request.address()
+        );
+        return toAddressResponse(member.getAddress());
+    }
+
+    @Transactional
+    public void deleteAddress(Long memberId) {
+        Member member = getMember(memberId);
+        if (member.getAddress() == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "address not found");
+        }
+        member.clearAddress();
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found"));
+    }
+
+    private MyPageResponseDto toMyPageResponse(Member member) {
+        SocialProvider provider = member.getProvider();
+        return new MyPageResponseDto(
+                member.getId(),
+                member.getUserName(),
+                member.getEmail(),
+                provider,
+                toAddressResponse(member.getAddress())
+        );
+    }
+
+    private MyPageAddressResponseDto toAddressResponse(MemberAddress address) {
+        if (address == null) {
+            return null;
+        }
+        return new MyPageAddressResponseDto(
+                address.getRecipientName(),
+                address.getPhoneNumber(),
+                address.getPostCode(),
+                address.getAddress()
+        );
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/media/presign-put").hasRole("ADMIN")
                         .requestMatchers("/api/media/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/mypage/**").hasRole("USER")
                         .requestMatchers("/api/**").permitAll()
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/com/example/cowmjucraft/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/jwt/JwtTokenProvider.java
@@ -32,8 +32,8 @@ public class JwtTokenProvider {
         return generateToken(loginId, Role.ROLE_ADMIN);
     }
 
-    public String generateMemberToken(String userId) {
-        return generateToken(userId, Role.ROLE_USER);
+    public String generateMemberToken(Long memberId) {
+        return generateToken(String.valueOf(memberId), Role.ROLE_USER);
     }
 
     private String generateToken(String subject, Role role) {


### PR DESCRIPTION
# 요약
소셜 로그인 기반으로 마이페이지 API 및 배송지 관리 기능을 추가하고 멤버 식별을 memberId로 전환했습니다.

# 작업 내용
- 마이페이지 API 추가 및 배송지 CRUD 구현
- 멤버 식별자 memberId로 전환(userId/password 제거) 및 소셜 로그인 응답에 userName 추가

# 기타 (논의하고 싶은 부분)
없음

# 타 직군 전달 사항
- 소셜 로그인 응답 필드가 memberId, userName, email, accessToken으로 변경됨
- 마이페이지 응답에서 loginType 제거, socialProvider만 유지