### PR TITLE
feat: 관리자 프로젝트 이미지 presign-put 배치 발급 API 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectController.java
@@ -2,9 +2,11 @@ package com.example.cowmjucraft.domain.project.controller.admin;
 
 import com.example.cowmjucraft.domain.project.dto.request.AdminProjectCreateRequestDto;
 import com.example.cowmjucraft.domain.project.dto.request.AdminProjectOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectPresignPutBatchRequestDto;
 import com.example.cowmjucraft.domain.project.dto.request.AdminProjectPresignPutRequestDto;
 import com.example.cowmjucraft.domain.project.dto.request.AdminProjectUpdateRequestDto;
 import com.example.cowmjucraft.domain.project.dto.response.AdminProjectOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.project.dto.response.AdminProjectPresignPutBatchResponseDto;
 import com.example.cowmjucraft.domain.project.dto.response.AdminProjectPresignPutResponseDto;
 import com.example.cowmjucraft.domain.project.dto.response.AdminProjectResponseDto;
 import com.example.cowmjucraft.domain.project.service.AdminProjectService;
@@ -44,12 +46,28 @@ public class AdminProjectController implements AdminProjectControllerDocs {
         return ApiResult.success(SuccessType.SUCCESS, adminProjectService.createThumbnailPresignPut(request));
     }
 
+    @PostMapping("/thumbnail/presign-put/batch")
+    @Override
+    public ApiResult<AdminProjectPresignPutBatchResponseDto> presignThumbnailBatch(
+            @Valid @RequestBody AdminProjectPresignPutBatchRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminProjectService.createThumbnailPresignPutBatch(request));
+    }
+
     @PostMapping("/images/presign-put")
     @Override
     public ApiResult<AdminProjectPresignPutResponseDto> presignImages(
             @Valid @RequestBody AdminProjectPresignPutRequestDto request
     ) {
         return ApiResult.success(SuccessType.SUCCESS, adminProjectService.createImagePresignPut(request));
+    }
+
+    @PostMapping("/images/presign-put/batch")
+    @Override
+    public ApiResult<AdminProjectPresignPutBatchResponseDto> presignImagesBatch(
+            @Valid @RequestBody AdminProjectPresignPutBatchRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminProjectService.createImagePresignPutBatch(request));
     }
 
     @PutMapping("/{projectId}")

--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
@@ -2,9 +2,11 @@ package com.example.cowmjucraft.domain.project.controller.admin;
 
 import com.example.cowmjucraft.domain.project.dto.request.AdminProjectCreateRequestDto;
 import com.example.cowmjucraft.domain.project.dto.request.AdminProjectOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.project.dto.request.AdminProjectPresignPutBatchRequestDto;
 import com.example.cowmjucraft.domain.project.dto.request.AdminProjectPresignPutRequestDto;
 import com.example.cowmjucraft.domain.project.dto.request.AdminProjectUpdateRequestDto;
 import com.example.cowmjucraft.domain.project.dto.response.AdminProjectOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.project.dto.response.AdminProjectPresignPutBatchResponseDto;
 import com.example.cowmjucraft.domain.project.dto.response.AdminProjectPresignPutResponseDto;
 import com.example.cowmjucraft.domain.project.dto.response.AdminProjectResponseDto;
 import com.example.cowmjucraft.global.response.ApiResult;
@@ -69,9 +71,14 @@ public interface AdminProjectControllerDocs {
                                                 "summary": "캠퍼스 감성을 담은 머그컵을 제작합니다.",
                                                 "description": "학생들이 함께 디자인한 머그컵 프로젝트입니다.",
                                                 "thumbnailKey": "uploads/projects/thumbnails/uuid-thumbnail.png",
+                                                "thumbnailUrl": "https://bucket.s3.amazonaws.com/uploads/projects/thumbnails/uuid-thumbnail.png?X-Amz-Signature=...",
                                                 "imageKeys": [
                                                   "uploads/projects/images/uuid-01.png",
                                                   "uploads/projects/images/uuid-02.png"
+                                                ],
+                                                "imageUrls": [
+                                                  "https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-01.png?X-Amz-Signature=...",
+                                                  "https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-02.png?X-Amz-Signature=..."
                                                 ],
                                                 "status": "OPEN",
                                                 "deadlineDate": "2026-03-15",
@@ -142,6 +149,68 @@ public interface AdminProjectControllerDocs {
     );
 
     @Operation(
+            summary = "프로젝트 썸네일 presign-put 배치 발급",
+            description = "프로젝트 썸네일 업로드용 presigned PUT URL을 여러 건 발급합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "presign-put 배치 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminProjectPresignPutBatchRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "thumbnail-presign-batch-request",
+                            value = """
+                                    {
+                                      "files": [
+                                        { "fileName": "thumbnail-1.png", "contentType": "image/png" },
+                                        { "fileName": "thumbnail-2.png", "contentType": "image/png" }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "thumbnail-presign-batch-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "요청에 성공하였습니다.",
+                                              "data": {
+                                                "items": [
+                                                  {
+                                                    "fileName": "thumbnail-1.png",
+                                                    "key": "uploads/projects/thumbnails/uuid-thumbnail-1.png",
+                                                    "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                                                    "expiresInSeconds": 300
+                                                  },
+                                                  {
+                                                    "fileName": "thumbnail-2.png",
+                                                    "key": "uploads/projects/thumbnails/uuid-thumbnail-2.png",
+                                                    "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                                                    "expiresInSeconds": 300
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류")
+    })
+    ApiResult<AdminProjectPresignPutBatchResponseDto> presignThumbnailBatch(
+            @Valid AdminProjectPresignPutBatchRequestDto request
+    );
+
+    @Operation(
             summary = "프로젝트 상세 이미지 presign-put 단건 발급",
             description = "프로젝트 상세 이미지 업로드용 presigned PUT URL을 발급합니다."
     )
@@ -191,6 +260,68 @@ public interface AdminProjectControllerDocs {
     );
 
     @Operation(
+            summary = "프로젝트 상세 이미지 presign-put 배치 발급",
+            description = "프로젝트 상세 이미지 업로드용 presigned PUT URL을 여러 건 발급합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "presign-put 배치 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminProjectPresignPutBatchRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "images-presign-batch-request",
+                            value = """
+                                    {
+                                      "files": [
+                                        { "fileName": "detail-1.png", "contentType": "image/png" },
+                                        { "fileName": "detail-2.png", "contentType": "image/png" }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "images-presign-batch-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "요청에 성공하였습니다.",
+                                              "data": {
+                                                "items": [
+                                                  {
+                                                    "fileName": "detail-1.png",
+                                                    "key": "uploads/projects/images/uuid-detail-1.png",
+                                                    "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                                                    "expiresInSeconds": 300
+                                                  },
+                                                  {
+                                                    "fileName": "detail-2.png",
+                                                    "key": "uploads/projects/images/uuid-detail-2.png",
+                                                    "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                                                    "expiresInSeconds": 300
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류")
+    })
+    ApiResult<AdminProjectPresignPutBatchResponseDto> presignImagesBatch(
+            @Valid AdminProjectPresignPutBatchRequestDto request
+    );
+
+    @Operation(
             summary = "프로젝트 수정",
             description = "프로젝트 기본 정보를 수정합니다."
     )
@@ -237,9 +368,14 @@ public interface AdminProjectControllerDocs {
                                                 "summary": "굿즈 라인업을 확장합니다.",
                                                 "description": "학생들이 함께 디자인한 머그컵 프로젝트입니다.",
                                                 "thumbnailKey": "uploads/projects/thumbnails/uuid-thumbnail.png",
+                                                "thumbnailUrl": "https://bucket.s3.amazonaws.com/uploads/projects/thumbnails/uuid-thumbnail.png?X-Amz-Signature=...",
                                                 "imageKeys": [
                                                   "uploads/projects/images/uuid-01.png",
                                                   "uploads/projects/images/uuid-02.png"
+                                                ],
+                                                "imageUrls": [
+                                                  "https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-01.png?X-Amz-Signature=...",
+                                                  "https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-02.png?X-Amz-Signature=..."
                                                 ],
                                                 "status": "OPEN",
                                                 "deadlineDate": "2026-03-20",

--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/client/ProjectControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/client/ProjectControllerDocs.java
@@ -52,9 +52,14 @@ public interface ProjectControllerDocs {
                                                 "summary": "캠퍼스 감성을 담은 머그컵을 제작합니다.",
                                                 "description": "학생들이 함께 디자인한 머그컵 프로젝트입니다.",
                                                 "thumbnailKey": "uploads/projects/thumbnails/uuid-thumbnail.png",
+                                                "thumbnailUrl": "https://bucket.s3.amazonaws.com/uploads/projects/thumbnails/uuid-thumbnail.png?X-Amz-Signature=...",
                                                 "imageKeys": [
                                                   "uploads/projects/images/uuid-01.png",
                                                   "uploads/projects/images/uuid-02.png"
+                                                ],
+                                                "imageUrls": [
+                                                  "https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-01.png?X-Amz-Signature=...",
+                                                  "https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-02.png?X-Amz-Signature=..."
                                                 ],
                                                 "status": "OPEN",
                                                 "deadlineDate": "2026-03-15",

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectPresignPutBatchRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectPresignPutBatchRequestDto.java
@@ -1,0 +1,35 @@
+package com.example.cowmjucraft.domain.project.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Schema(description = "프로젝트 presign-put 배치 요청")
+public record AdminProjectPresignPutBatchRequestDto(
+
+        @Valid
+        @NotEmpty
+        @Schema(
+                description = "업로드 파일 목록",
+                example = """
+                        [
+                          { "fileName": "thumbnail-1.png", "contentType": "image/png" },
+                          { "fileName": "thumbnail-2.png", "contentType": "image/png" }
+                        ]
+                        """
+        )
+        List<FileDto> files
+) {
+    public record FileDto(
+            @NotBlank
+            @Schema(description = "원본 파일명", example = "thumbnail.png")
+            String fileName,
+
+            @NotBlank
+            @Schema(description = "파일 Content-Type", example = "image/png")
+            String contentType
+    ) {
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectPresignPutBatchResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectPresignPutBatchResponseDto.java
@@ -1,0 +1,44 @@
+package com.example.cowmjucraft.domain.project.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "프로젝트 presign-put 배치 응답")
+public record AdminProjectPresignPutBatchResponseDto(
+
+        @Schema(
+                description = "발급된 presign-put 항목 목록",
+                example = """
+                        [
+                          {
+                            "fileName": "thumbnail-1.png",
+                            "key": "uploads/projects/thumbnails/uuid-thumbnail-1.png",
+                            "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                            "expiresInSeconds": 300
+                          },
+                          {
+                            "fileName": "thumbnail-2.png",
+                            "key": "uploads/projects/thumbnails/uuid-thumbnail-2.png",
+                            "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                            "expiresInSeconds": 300
+                          }
+                        ]
+                        """
+        )
+        List<ItemDto> items
+) {
+    public record ItemDto(
+            @Schema(description = "요청 파일명", example = "thumbnail.png")
+            String fileName,
+
+            @Schema(description = "S3 key", example = "uploads/projects/thumbnails/uuid-thumbnail.png")
+            String key,
+
+            @Schema(description = "Presigned PUT URL", example = "https://bucket.s3.amazonaws.com/...")
+            String uploadUrl,
+
+            @Schema(description = "URL 만료 시간(초)", example = "300")
+            int expiresInSeconds
+    ) {
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectResponseDto.java
@@ -24,8 +24,14 @@ public record AdminProjectResponseDto(
         @Schema(description = "썸네일 S3 key", example = "uploads/projects/thumbnail-001.png")
         String thumbnailKey,
 
+        @Schema(description = "썸네일 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/projects/thumbnail-001.png?X-Amz-Signature=...")
+        String thumbnailUrl,
+
         @Schema(description = "프로젝트 상세 이미지 S3 object key 목록(정렬 순서대로)", example = "[\"uploads/projects/images/uuid-01.png\", \"uploads/projects/images/uuid-02.png\"]")
         List<String> imageKeys,
+
+        @Schema(description = "프로젝트 상세 이미지 URL 목록(정렬 순서대로)", example = "[\"https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-01.png?X-Amz-Signature=...\", \"https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-02.png?X-Amz-Signature=...\"]")
+        List<String> imageUrls,
 
         @Schema(description = "프로젝트 상태", example = "OPEN")
         ProjectStatus status,

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectDetailResponseDto.java
@@ -21,11 +21,25 @@ public record ProjectDetailResponseDto(
         @Schema(description = "프로젝트 상세 설명", example = "학생들이 함께 디자인한 머그컵 프로젝트입니다.")
         String description,
 
-        @Schema(description = "썸네일 S3 key", example = "uploads/projects/thumbnail-001.png")
+        @Schema(
+                description = "썸네일 S3 key",
+                example = "uploads/projects/thumbnail-001.png",
+                deprecated = true
+        )
         String thumbnailKey,
 
-        @Schema(description = "프로젝트 상세 이미지 S3 object key 목록(정렬 순서대로)", example = "[\"uploads/projects/images/uuid-01.png\", \"uploads/projects/images/uuid-02.png\"]")
+        @Schema(description = "썸네일 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/projects/thumbnail-001.png?X-Amz-Signature=...")
+        String thumbnailUrl,
+
+        @Schema(
+                description = "프로젝트 상세 이미지 S3 object key 목록(정렬 순서대로)",
+                example = "[\"uploads/projects/images/uuid-01.png\", \"uploads/projects/images/uuid-02.png\"]",
+                deprecated = true
+        )
         List<String> imageKeys,
+
+        @Schema(description = "프로젝트 상세 이미지 URL 목록(정렬 순서대로)", example = "[\"https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-01.png?X-Amz-Signature=...\", \"https://bucket.s3.amazonaws.com/uploads/projects/images/uuid-02.png?X-Amz-Signature=...\"]")
+        List<String> imageUrls,
 
         @Schema(description = "프로젝트 상태", example = "OPEN")
         ProjectStatus status,

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectListItemResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectListItemResponseDto.java
@@ -16,8 +16,15 @@ public record ProjectListItemResponseDto(
         @Schema(description = "리스트 한줄 소개", example = "캠퍼스 감성을 담은 머그컵을 제작합니다.")
         String summary,
 
-        @Schema(description = "썸네일 S3 key", example = "uploads/projects/thumbnail-001.png")
+        @Schema(
+                description = "썸네일 S3 key",
+                example = "uploads/projects/thumbnail-001.png",
+                deprecated = true
+        )
         String thumbnailKey,
+
+        @Schema(description = "썸네일 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/projects/thumbnail-001.png?X-Amz-Signature=...")
+        String thumbnailUrl,
 
         @Schema(description = "프로젝트 상태", example = "OPEN")
         ProjectStatus status,

--- a/src/main/java/com/example/cowmjucraft/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/service/ProjectService.java
@@ -4,9 +4,14 @@ import com.example.cowmjucraft.domain.project.dto.response.ProjectDetailResponse
 import com.example.cowmjucraft.domain.project.dto.response.ProjectListItemResponseDto;
 import com.example.cowmjucraft.domain.project.entity.Project;
 import com.example.cowmjucraft.domain.project.repository.ProjectRepository;
+import com.example.cowmjucraft.global.cloud.S3PresignFacade;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,20 +21,29 @@ import org.springframework.web.server.ResponseStatusException;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final S3PresignFacade s3PresignFacade;
 
-    public ProjectService(ProjectRepository projectRepository) {
+    public ProjectService(ProjectRepository projectRepository, S3PresignFacade s3PresignFacade) {
         this.projectRepository = projectRepository;
+        this.s3PresignFacade = s3PresignFacade;
     }
 
     @Transactional(readOnly = true)
     public List<ProjectListItemResponseDto> getProjects() {
         List<Project> projects = projectRepository.findAllOrderedForPublic();
+        Set<String> keySet = new LinkedHashSet<>();
+        for (Project project : projects) {
+            addIfValidKey(keySet, project.getThumbnailKey());
+        }
+        Map<String, String> urls = presignGetSafely(keySet);
+
         return projects.stream()
                 .map(project -> new ProjectListItemResponseDto(
                         project.getId(),
                         project.getTitle(),
                         project.getSummary(),
                         project.getThumbnailKey(),
+                        resolveUrl(urls, project.getThumbnailKey()),
                         project.getStatus(),
                         project.getDeadlineDate(),
                         calculateDDay(project.getDeadlineDate()),
@@ -43,13 +57,20 @@ public class ProjectService {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "project not found"));
 
+        Set<String> keySet = new LinkedHashSet<>();
+        addIfValidKey(keySet, project.getThumbnailKey());
+        addIfValidKey(keySet, project.getImageKeys());
+        Map<String, String> urls = presignGetSafely(keySet);
+
         return new ProjectDetailResponseDto(
                 project.getId(),
                 project.getTitle(),
                 project.getSummary(),
                 project.getDescription(),
                 project.getThumbnailKey(),
+                resolveUrl(urls, project.getThumbnailKey()),
                 project.getImageKeys(),
+                buildUrlsForKeys(project.getImageKeys(), urls),
                 project.getStatus(),
                 project.getDeadlineDate(),
                 calculateDDay(project.getDeadlineDate()),
@@ -60,5 +81,52 @@ public class ProjectService {
 
     private long calculateDDay(LocalDate deadlineDate) {
         return ChronoUnit.DAYS.between(LocalDate.now(), deadlineDate);
+    }
+
+    private Map<String, String> presignGetSafely(Set<String> keys) {
+        try {
+            return keys == null || keys.isEmpty()
+                    ? Map.of()
+                    : s3PresignFacade.presignGet(new ArrayList<>(keys));
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+    private String resolveUrl(Map<String, String> urls, String key) {
+        String k = toNonBlankString(key);
+        return k == null ? null : urls.get(k);
+    }
+
+    private List<String> buildUrlsForKeys(List<String> keys, Map<String, String> urls) {
+        if (keys == null || keys.isEmpty()) {
+            return List.of();
+        }
+        List<String> result = new ArrayList<>(keys.size());
+        for (String key : keys) {
+            String normalized = toNonBlankString(key);
+            result.add(normalized == null ? null : urls.get(normalized));
+        }
+        return result;
+    }
+
+    private void addIfValidKey(Set<String> keys, String value) {
+        String k = toNonBlankString(value);
+        if (k != null) {
+            keys.add(k);
+        }
+    }
+
+    private void addIfValidKey(Set<String> keys, List<String> values) {
+        if (values == null) {
+            return;
+        }
+        for (String value : values) {
+            addIfValidKey(keys, value);
+        }
+    }
+
+    private String toNonBlankString(String value) {
+        return value == null || value.trim().isEmpty() ? null : value.trim();
     }
 }


### PR DESCRIPTION
# 요약

관리자 프로젝트 이미지 업로드를 위한 presign-put API에 배치 발급 기능을 추가했습니다.  
기존 단건 발급 API는 유지하면서, 여러 이미지를 한 번에 업로드할 수 있도록 확장했습니다.

---

# 작업 내용

- 관리자 프로젝트 썸네일 presign-put **배치 발급 API 추가**
  - `/api/admin/projects/thumbnail/presign-put/batch`
  - 여러 썸네일 업로드를 위한 presigned PUT URL을 한 번에 발급

- 관리자 프로젝트 상세 이미지 presign-put **배치 발급 API 추가**
  - `/api/admin/projects/images/presign-put/batch`
  - 다중 상세 이미지 업로드 지원

- 배치 presign-put 요청/응답 DTO 추가
  - `AdminProjectPresignPutBatchRequestDto`
  - `AdminProjectPresignPutBatchResponseDto`

- AdminProjectService에 배치 presign-put 처리 로직 구현
  - 입력 파일 검증 강화
  - S3PresignFacade batch API 활용

- 기존 단건 presign-put API 및 public 조회 API는 변경 없음

