### PR TITLE
feat: 물품 이미지/썸네일 presign-put 배치 발급 및 조회 URL 응답 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
@@ -2,10 +2,12 @@ package com.example.cowmjucraft.domain.item.controller.admin;
 
 import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageCreateRequestDto;
 import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminItemPresignPutBatchRequestDto;
 import com.example.cowmjucraft.domain.item.dto.request.AdminItemPresignPutRequestDto;
 import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemCreateRequestDto;
 import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemUpdateRequestDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminItemImageOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminItemPresignPutBatchResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminItemPresignPutResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
@@ -58,6 +60,18 @@ public class AdminItemController implements AdminItemControllerDocs {
         return ApiResult.success(SuccessType.SUCCESS, adminItemService.createThumbnailPresignPut(itemId, request));
     }
 
+    @PostMapping("/items/{itemId}/thumbnail/presign-put/batch")
+    @Override
+    public ApiResult<AdminItemPresignPutBatchResponseDto> presignThumbnailBatch(
+            @PathVariable Long itemId,
+            @Valid @RequestBody AdminItemPresignPutBatchRequestDto request
+    ) {
+        return ApiResult.success(
+                SuccessType.SUCCESS,
+                adminItemService.createThumbnailPresignPutBatch(itemId, request)
+        );
+    }
+
     @PostMapping("/items/{itemId}/images/presign-put")
     @Override
     public ApiResult<AdminItemPresignPutResponseDto> presignImage(
@@ -65,6 +79,18 @@ public class AdminItemController implements AdminItemControllerDocs {
             @Valid @RequestBody AdminItemPresignPutRequestDto request
     ) {
         return ApiResult.success(SuccessType.SUCCESS, adminItemService.createImagePresignPut(itemId, request));
+    }
+
+    @PostMapping("/items/{itemId}/images/presign-put/batch")
+    @Override
+    public ApiResult<AdminItemPresignPutBatchResponseDto> presignImageBatch(
+            @PathVariable Long itemId,
+            @Valid @RequestBody AdminItemPresignPutBatchRequestDto request
+    ) {
+        return ApiResult.success(
+                SuccessType.SUCCESS,
+                adminItemService.createImagePresignPutBatch(itemId, request)
+        );
     }
 
     @DeleteMapping("/items/{itemId}")

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
@@ -2,10 +2,12 @@ package com.example.cowmjucraft.domain.item.controller.admin;
 
 import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageCreateRequestDto;
 import com.example.cowmjucraft.domain.item.dto.request.AdminItemImageOrderPatchRequestDto;
+import com.example.cowmjucraft.domain.item.dto.request.AdminItemPresignPutBatchRequestDto;
 import com.example.cowmjucraft.domain.item.dto.request.AdminItemPresignPutRequestDto;
 import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemCreateRequestDto;
 import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemUpdateRequestDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminItemImageOrderPatchResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminItemPresignPutBatchResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminItemPresignPutResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
@@ -73,6 +75,7 @@ public interface AdminItemControllerDocs {
                                                 "saleType": "GROUPBUY",
                                                 "status": "OPEN",
                                                 "thumbnailKey": "uploads/items/1/thumbnail/uuid-thumbnail.png",
+                                                "thumbnailUrl": "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png?X-Amz-Signature=...",
                                                 "targetQty": 100,
                                                 "fundedQty": 0,
                                                 "achievementRate": 0.0,
@@ -186,6 +189,71 @@ public interface AdminItemControllerDocs {
     );
 
     @Operation(
+            summary = "물품 썸네일 presign-put 배치 발급",
+            description = "물품 썸네일 업로드용 presigned PUT URL을 여러 건 발급합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "presign-put 배치 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminItemPresignPutBatchRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "item-thumbnail-presign-batch-request",
+                            value = """
+                                    {
+                                      "files": [
+                                        { "fileName": "thumbnail-1.png", "contentType": "image/png" },
+                                        { "fileName": "thumbnail-2.png", "contentType": "image/png" }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "item-thumbnail-presign-batch-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "요청에 성공하였습니다.",
+                                              "data": {
+                                                "items": [
+                                                  {
+                                                    "fileName": "thumbnail-1.png",
+                                                    "key": "uploads/items/1/thumbnail/uuid-thumbnail-1.png",
+                                                    "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                                                    "expiresInSeconds": 300
+                                                  },
+                                                  {
+                                                    "fileName": "thumbnail-2.png",
+                                                    "key": "uploads/items/1/thumbnail/uuid-thumbnail-2.png",
+                                                    "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                                                    "expiresInSeconds": 300
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<AdminItemPresignPutBatchResponseDto> presignThumbnailBatch(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId,
+            @Valid AdminItemPresignPutBatchRequestDto request
+    );
+
+    @Operation(
             summary = "물품 상세 이미지 presign-put 발급",
             description = "물품 상세 이미지 업로드용 presigned PUT URL을 발급합니다."
     )
@@ -235,6 +303,71 @@ public interface AdminItemControllerDocs {
             @Parameter(description = "물품 ID", example = "1")
             Long itemId,
             @Valid AdminItemPresignPutRequestDto request
+    );
+
+    @Operation(
+            summary = "물품 상세 이미지 presign-put 배치 발급",
+            description = "물품 상세 이미지 업로드용 presigned PUT URL을 여러 건 발급합니다."
+    )
+    @RequestBody(
+            required = true,
+            description = "presign-put 배치 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminItemPresignPutBatchRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "item-image-presign-batch-request",
+                            value = """
+                                    {
+                                      "files": [
+                                        { "fileName": "detail-1.png", "contentType": "image/png" },
+                                        { "fileName": "detail-2.png", "contentType": "image/png" }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "item-image-presign-batch-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "요청에 성공하였습니다.",
+                                              "data": {
+                                                "items": [
+                                                  {
+                                                    "fileName": "detail-1.png",
+                                                    "key": "uploads/items/1/images/uuid-detail-1.png",
+                                                    "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                                                    "expiresInSeconds": 300
+                                                  },
+                                                  {
+                                                    "fileName": "detail-2.png",
+                                                    "key": "uploads/items/1/images/uuid-detail-2.png",
+                                                    "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                                                    "expiresInSeconds": 300
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<AdminItemPresignPutBatchResponseDto> presignImageBatch(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId,
+            @Valid AdminItemPresignPutBatchRequestDto request
     );
 
     @Operation(
@@ -306,6 +439,7 @@ public interface AdminItemControllerDocs {
                                                 {
                                                   "id": 5,
                                                   "imageKey": "uploads/items/1/images/uuid-detail-01.png",
+                                                  "imageUrl": "https://bucket.s3.amazonaws.com/uploads/items/1/images/uuid-detail-01.png?X-Amz-Signature=...",
                                                   "sortOrder": 0
                                                 }
                                               ]

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemControllerDocs.java
@@ -41,6 +41,7 @@ public interface ItemControllerDocs {
                                                   "saleType": "GROUPBUY",
                                                   "status": "OPEN",
                                                   "thumbnailKey": "uploads/items/1/thumbnail/uuid-thumbnail.png",
+                                                  "thumbnailUrl": "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png?X-Amz-Signature=...",
                                                   "targetQty": 100,
                                                   "fundedQty": 40,
                                                   "achievementRate": 40.0,
@@ -85,10 +86,12 @@ public interface ItemControllerDocs {
                                                 "saleType": "GROUPBUY",
                                                 "status": "OPEN",
                                                 "thumbnailKey": "uploads/items/1/thumbnail/uuid-thumbnail.png",
+                                                "thumbnailUrl": "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png?X-Amz-Signature=...",
                                                 "images": [
                                                   {
                                                     "id": 5,
                                                     "imageKey": "uploads/items/1/images/uuid-detail-01.png",
+                                                    "imageUrl": "https://bucket.s3.amazonaws.com/uploads/items/1/images/uuid-detail-01.png?X-Amz-Signature=...",
                                                     "sortOrder": 0
                                                   }
                                                 ],

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminItemPresignPutBatchRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminItemPresignPutBatchRequestDto.java
@@ -1,0 +1,35 @@
+package com.example.cowmjucraft.domain.item.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Schema(description = "물품 presign-put 배치 요청")
+public record AdminItemPresignPutBatchRequestDto(
+
+        @Valid
+        @NotEmpty
+        @Schema(
+                description = "업로드 파일 목록",
+                example = """
+                        [
+                          { \"fileName\": \"thumbnail-1.png\", \"contentType\": \"image/png\" },
+                          { \"fileName\": \"thumbnail-2.png\", \"contentType\": \"image/png\" }
+                        ]
+                        """
+        )
+        List<FileDto> files
+) {
+    public record FileDto(
+            @NotBlank
+            @Schema(description = "원본 파일명", example = "thumbnail.png")
+            String fileName,
+
+            @NotBlank
+            @Schema(description = "파일 Content-Type", example = "image/png")
+            String contentType
+    ) {
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminItemPresignPutBatchResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminItemPresignPutBatchResponseDto.java
@@ -1,0 +1,44 @@
+package com.example.cowmjucraft.domain.item.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "물품 presign-put 배치 응답")
+public record AdminItemPresignPutBatchResponseDto(
+
+        @Schema(
+                description = "발급된 presign-put 항목 목록",
+                example = """
+                        [
+                          {
+                            \"fileName\": \"thumbnail-1.png\",
+                            \"key\": \"uploads/items/1/thumbnail/uuid-thumbnail-1.png\",
+                            \"uploadUrl\": \"https://bucket.s3.amazonaws.com/...\",
+                            \"expiresInSeconds\": 300
+                          },
+                          {
+                            \"fileName\": \"thumbnail-2.png\",
+                            \"key\": \"uploads/items/1/thumbnail/uuid-thumbnail-2.png\",
+                            \"uploadUrl\": \"https://bucket.s3.amazonaws.com/...\",
+                            \"expiresInSeconds\": 300
+                          }
+                        ]
+                        """
+        )
+        List<ItemDto> items
+) {
+    public record ItemDto(
+            @Schema(description = "요청 파일명", example = "thumbnail.png")
+            String fileName,
+
+            @Schema(description = "S3 key", example = "uploads/items/1/thumbnail/uuid-thumbnail.png")
+            String key,
+
+            @Schema(description = "Presigned PUT URL", example = "https://bucket.s3.amazonaws.com/...")
+            String uploadUrl,
+
+            @Schema(description = "URL 만료 시간(초)", example = "300")
+            int expiresInSeconds
+    ) {
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemResponseDto.java
@@ -33,6 +33,9 @@ public record AdminProjectItemResponseDto(
         @Schema(description = "대표 이미지 S3 object key", example = "uploads/items/1/thumbnail/uuid-thumbnail.png")
         String thumbnailKey,
 
+        @Schema(description = "대표 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png?X-Amz-Signature=...")
+        String thumbnailUrl,
+
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
         Integer targetQty,

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemDetailResponseDto.java
@@ -30,8 +30,15 @@ public record ProjectItemDetailResponseDto(
         @Schema(description = "상태", example = "OPEN")
         ItemStatus status,
 
-        @Schema(description = "대표 이미지 S3 object key", example = "uploads/items/1/thumbnail/uuid-thumbnail.png")
+        @Schema(
+                description = "대표 이미지 S3 object key",
+                example = "uploads/items/1/thumbnail/uuid-thumbnail.png",
+                deprecated = true
+        )
         String thumbnailKey,
+
+        @Schema(description = "대표 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png?X-Amz-Signature=...")
+        String thumbnailUrl,
 
         @Schema(description = "상세 이미지 목록")
         List<ProjectItemImageResponseDto> images,

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemImageResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemImageResponseDto.java
@@ -9,8 +9,15 @@ public record ProjectItemImageResponseDto(
         @Schema(description = "이미지 ID", example = "10")
         Long id,
 
-        @Schema(description = "이미지 S3 object key", example = "uploads/items/1/images/uuid-detail.png")
+        @Schema(
+                description = "이미지 S3 object key",
+                example = "uploads/items/1/images/uuid-detail.png",
+                deprecated = true
+        )
         String imageKey,
+
+        @Schema(description = "이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/items/1/images/uuid-detail.png?X-Amz-Signature=...")
+        String imageUrl,
 
         @Schema(description = "정렬 순서", example = "0")
         int sortOrder
@@ -19,6 +26,7 @@ public record ProjectItemImageResponseDto(
         return new ProjectItemImageResponseDto(
                 image.getId(),
                 image.getImageKey(),
+                null,
                 image.getSortOrder()
         );
     }

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemListResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemListResponseDto.java
@@ -23,8 +23,15 @@ public record ProjectItemListResponseDto(
         @Schema(description = "상태", example = "OPEN")
         ItemStatus status,
 
-        @Schema(description = "대표 이미지 S3 object key", example = "uploads/items/1/thumbnail/uuid-thumbnail.png")
+        @Schema(
+                description = "대표 이미지 S3 object key",
+                example = "uploads/items/1/thumbnail/uuid-thumbnail.png",
+                deprecated = true
+        )
         String thumbnailKey,
+
+        @Schema(description = "대표 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png?X-Amz-Signature=...")
+        String thumbnailUrl,
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")


### PR DESCRIPTION
# 요약

물품(Item) 도메인에서 이미지 업로드 및 조회 흐름을 개선하였습니다.  
관리자 API에 썸네일/상세 이미지 **presign-put 단건·배치 발급 기능**을 추가하고,  
관리자/공개 조회 API 응답에 **S3 이미지 접근 URL을 함께 제공**하도록 수정했습니다.

# 작업 내용

- 관리자 물품 API
  - 썸네일 / 상세 이미지 presign-put **배치 발급 API 추가**
  - presign-put 응답에 fileName, key, uploadUrl, expiresInSeconds 포함
  - 물품 생성/수정/이미지 등록 응답에 thumbnailUrl / imageUrl 필드 추가
  - 이미지 key 필드는 deprecated 처리 (URL 기반 사용 유도)

- 공개 물품 조회 API
  - 물품 목록 / 상세 조회 시 대표 이미지 URL(thumbnailUrl) 제공
  - 상세 조회 시 이미지 목록에 imageUrl 포함하여 반환

- 공통
  - S3 presign-get을 활용한 이미지 URL 일괄 조회 로직 추가
  - Swagger 문서 응답 예시 및 스펙 실제 코드와 일치하도록 정리
