### PR TITLE
feat: 관리자 프로젝트 조회 API 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectController.java
@@ -11,8 +11,10 @@ import com.example.cowmjucraft.domain.project.service.AdminProjectService;
 import com.example.cowmjucraft.global.response.ApiResult;
 import com.example.cowmjucraft.global.response.type.SuccessType;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,6 +36,20 @@ public class AdminProjectController implements AdminProjectControllerDocs {
             @Valid @RequestBody AdminProjectCreateRequestDto request
     ) {
         return ApiResult.success(SuccessType.CREATED, adminProjectService.create(request));
+    }
+
+    @GetMapping
+    @Override
+    public ApiResult<List<AdminProjectResponseDto>> getProjects() {
+        return ApiResult.success(SuccessType.SUCCESS, adminProjectService.getProjects());
+    }
+
+    @GetMapping("/{projectId}")
+    @Override
+    public ApiResult<AdminProjectResponseDto> getProject(
+            @PathVariable Long projectId
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminProjectService.getProject(projectId));
     }
 
     @PostMapping("/thumbnail/presign-put")

--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
@@ -18,9 +18,40 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
+import java.util.List;
 
 @Tag(name = "Project - Admin", description = "프로젝트 관리자 API")
 public interface AdminProjectControllerDocs {
+
+    @Operation(
+            summary = "프로젝트 전체 조회",
+            description = "프로젝트 목록을 관리자 관점으로 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            )
+    })
+    ApiResult<List<AdminProjectResponseDto>> getProjects();
+
+    @Operation(
+            summary = "프로젝트 상세 조회",
+            description = "프로젝트 상세를 관리자 관점으로 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
+    })
+    ApiResult<AdminProjectResponseDto> getProject(
+            @Parameter(description = "프로젝트 ID", example = "1")
+            Long projectId
+    );
 
     @Operation(
             summary = "프로젝트 생성",


### PR DESCRIPTION
# 요약
관리자 프로젝트 조회 API를 추가했습니다.  
관리자도 프로젝트를 전체 조회 및 상세 조회할 수 있도록 하였으며,  
공개 조회와 동일한 정렬 기준을 사용합니다.

---

# 작업 내용
- 관리자 프로젝트 전체 조회 API 추가  
  - `GET /api/admin/projects`
  - 공개(Project Public) 조회와 동일한 정렬 기준 사용
  - presigned GET URL을 일괄 발급하여 N+1 호출 방지

- 관리자 프로젝트 상세 조회 API 추가  
  - `GET /api/admin/projects/{projectId}`
  - 관리자 관점에서 프로젝트의 모든 정보 반환
  - 썸네일/이미지 presigned GET URL 포함

---

# 기타 (논의하고 싶은 부분)
- 관리자 전체 조회 응답에 모든 필드를 포함하고 있습니다.  
  현재는 프론트에서 필요한 필드만 사용하는 방향으로 진행합니다.
- 날짜(`LocalDate`, `LocalDateTime`) 응답 포맷은 배열 형태이며,  
  ISO 문자열로 통일하는 작업은 별도 이슈로 분리 예정입니다.
