### PR TITLE
feat: 관리자 물품 조회 API 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
@@ -7,6 +7,7 @@ import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemCreateReq
 import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemUpdateRequestDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminItemImageOrderPatchResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminItemPresignPutBatchResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemDetailResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
 import com.example.cowmjucraft.domain.item.service.AdminItemService;
@@ -16,6 +17,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,6 +40,22 @@ public class AdminItemController implements AdminItemControllerDocs {
             @Valid @RequestBody AdminProjectItemCreateRequestDto request
     ) {
         return ApiResult.success(SuccessType.CREATED, adminItemService.create(projectId, request));
+    }
+
+    @GetMapping("/projects/{projectId}/items")
+    @Override
+    public ApiResult<List<AdminProjectItemResponseDto>> getItems(
+            @PathVariable Long projectId
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminItemService.getItems(projectId));
+    }
+
+    @GetMapping("/items/{itemId}")
+    @Override
+    public ApiResult<AdminProjectItemDetailResponseDto> getItem(
+            @PathVariable Long itemId
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, adminItemService.getItem(itemId));
     }
 
     @PutMapping("/items/{itemId}")

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
@@ -7,6 +7,7 @@ import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemCreateReq
 import com.example.cowmjucraft.domain.item.dto.request.AdminProjectItemUpdateRequestDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminItemImageOrderPatchResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminItemPresignPutBatchResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemDetailResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
 import com.example.cowmjucraft.global.response.ApiResult;
@@ -24,6 +25,40 @@ import java.util.List;
 
 @Tag(name = "Item - Admin", description = "물품 관리자 API")
 public interface AdminItemControllerDocs {
+
+    @Operation(
+            summary = "프로젝트 물품 목록 조회 (관리자)",
+            description = "프로젝트 물품 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
+    })
+    ApiResult<List<AdminProjectItemResponseDto>> getItems(
+            @Parameter(description = "프로젝트 ID", example = "1")
+            Long projectId
+    );
+
+    @Operation(
+            summary = "물품 상세 조회 (관리자)",
+            description = "물품 상세 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
+    })
+    ApiResult<AdminProjectItemDetailResponseDto> getItem(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId
+    );
 
     @Operation(
             summary = "프로젝트 물품 생성",

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemDetailResponseDto.java
@@ -1,0 +1,65 @@
+package com.example.cowmjucraft.domain.item.dto.response;
+
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "프로젝트 물품 관리자 상세 응답")
+public record AdminProjectItemDetailResponseDto(
+
+        @Schema(description = "물품 ID", example = "1")
+        Long id,
+
+        @Schema(description = "프로젝트 ID", example = "10")
+        Long projectId,
+
+        @Schema(description = "물품명", example = "명지공방 머그컵")
+        String name,
+
+        @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
+        String description,
+
+        @Schema(description = "가격", example = "12000")
+        int price,
+
+        @Schema(description = "판매 유형", example = "GROUPBUY")
+        ItemSaleType saleType,
+
+        @Schema(description = "상태", example = "OPEN")
+        ItemStatus status,
+
+        @Schema(description = "대표 이미지 S3 object key", example = "uploads/items/1/thumbnail/uuid-thumbnail.png")
+        String thumbnailKey,
+
+        @Schema(description = "대표 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png?X-Amz-Signature=...")
+        String thumbnailUrl,
+
+        @Schema(description = "상세 이미지 목록")
+        List<ProjectItemImageResponseDto> images,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
+        Integer targetQty,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "현재 모금 수량 (GROUPBUY 전용)", example = "40")
+        Integer fundedQty,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "달성률(%) (GROUPBUY 전용)", example = "40.0")
+        Double achievementRate,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "남은 수량 (GROUPBUY 전용)", example = "60")
+        Integer remainingQty,
+
+        @Schema(description = "생성 시각")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정 시각")
+        LocalDateTime updatedAt
+) {
+}


### PR DESCRIPTION
# 요약

프로젝트 물품(Item) 관리자 조회 API를 추가하고,
관리자 물품 상세 조회 응답에 상세 이미지 목록(images) 을 포함하도록 확장했습니다.

# 작업 내용

• 관리자 물품 목록 조회 API 추가
• GET /api/admin/projects/{projectId}/items
• 프로젝트에 속한 물품 목록을 최신순으로 조회
• 관리자 물품 상세 조회 API 추가
• GET /api/admin/items/{itemId}
• 물품 기본 정보 + 상세 이미지 목록(images) 포함
• 관리자 물품 상세 응답 DTO 확장
• AdminProjectItemDetailResponseDto 신규 추가
• images, thumbnailUrl, imageUrl 포함
• 이미지 presigned GET URL 처리
• 썸네일 및 상세 이미지 key 기준으로 presigned GET URL 발급 후 응답에 매핑
