### PR TITLE
feat: pinnedOrder 직접 지정 기능 추가 및 pinned 전체 세트 검증

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
@@ -367,6 +367,9 @@ public interface AdminProjectControllerDocs {
                     items에 포함된 프로젝트만 갱신되며, 포함되지 않은 프로젝트는 기존 값을 유지합니다.
                     pinned=false & manualOrder=null 인 경우 자동정렬 대상으로 저장됩니다.
                     manualOrder는 1 이상이며 pinned=true일 때는 manualOrder를 보낼 수 없습니다.
+                    pinned=true일 때 pinnedOrder는 1 이상 필수이며 pinned=true 항목 내에서 중복 불가합니다.
+                    pinned=true 항목의 pinnedOrder를 변경하는 경우, 현재 pinned=true인 전체 프로젝트를 items에 포함해야 합니다.
+                    (부분 업데이트는 허용되지 않습니다.)
                     """
     )
     @RequestBody(
@@ -379,9 +382,9 @@ public interface AdminProjectControllerDocs {
                             value = """
                                     {
                                       "items": [
-                                        { "projectId": 3, "pinned": true },
-                                        { "projectId": 1, "pinned": true },
-                                        { "projectId": 7, "pinned": true },
+                                        { "projectId": 3, "pinned": true, "pinnedOrder": 1 },
+                                        { "projectId": 1, "pinned": true, "pinnedOrder": 2 },
+                                        { "projectId": 7, "pinned": true, "pinnedOrder": 3 },
                                         { "projectId": 10, "pinned": false, "manualOrder": 1 },
                                         { "projectId": 12, "pinned": false, "manualOrder": 2 }
                                       ]

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectOrderPatchRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectOrderPatchRequestDto.java
@@ -27,6 +27,9 @@ public record AdminProjectOrderPatchRequestDto(
             @Schema(description = "고정 여부", example = "true")
             Boolean pinned,
 
+            @Schema(description = "고정 정렬 순서 (pinned=true인 경우만 적용)", example = "1")
+            Integer pinnedOrder,
+
             @Schema(description = "수동 정렬 순서 (pinned=false인 경우만 적용)", example = "1")
             Integer manualOrder
     ) {

--- a/src/main/java/com/example/cowmjucraft/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/repository/ProjectRepository.java
@@ -20,4 +20,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
         p.id desc
 """)
     List<Project> findAllOrderedForPublic();
+
+    @Query("select p.id from Project p where p.pinned = true")
+    List<Long> findPinnedIds();
 }


### PR DESCRIPTION
# 요약

관리자 프로젝트 정렬 기능에서 `pinnedOrder`를 직접 지정할 수 있도록 개선하고,  
pinned 항목의 부분 업데이트로 인해 발생할 수 있는 정렬 충돌을 방지하는 검증 로직을 추가했습니다.

---

# 작업 내용

- pinned=true 프로젝트에 대해 `pinnedOrder`를 요청으로 직접 지정할 수 있도록 기능 확장
- pinned=true / pinned=false 상태에 따라 `pinnedOrder`, `manualOrder`를 상호 배타적으로 검증하도록 개선
- pinnedOrder 변경 시 현재 pinned=true인 전체 프로젝트를 요청에 포함하도록 정책을 명확히 하고 검증 로직 추가
- 정렬 변경 요청에서 `items[i] == null` 케이스를 방어하여 NPE 발생 가능성 제거
- Swagger 문서에 pinnedOrder 사용 규칙 및 전체 세트 업데이트 정책 설명 추가