### PR TITLE
feat: 프로젝트 고정(pinned) 토글 및 정렬 일괄 변경 로직 개선

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectControllerDocs.java
@@ -365,11 +365,12 @@ public interface AdminProjectControllerDocs {
             description = """
                     고정 여부 및 정렬 순서를 일괄로 반영합니다.
                     items에 포함된 프로젝트만 갱신되며, 포함되지 않은 프로젝트는 기존 값을 유지합니다.
+                    pinned 집합 변경(고정 추가/해제)을 허용합니다.
                     pinned=false & manualOrder=null 인 경우 자동정렬 대상으로 저장됩니다.
                     manualOrder는 1 이상이며 pinned=true일 때는 manualOrder를 보낼 수 없습니다.
-                    pinned=true일 때 pinnedOrder는 1 이상 필수이며 pinned=true 항목 내에서 중복 불가합니다.
-                    pinned=true 항목의 pinnedOrder를 변경하는 경우, 현재 pinned=true인 전체 프로젝트를 items에 포함해야 합니다.
-                    (부분 업데이트는 허용되지 않습니다.)
+                    pinned=true일 때 pinnedOrder는 선택값이며 1 이상일 경우 pinned=true 항목 내에서 중복 불가합니다.
+                    pinnedOrder는 pinned=true 전체 프로젝트에 대해 서버가 1..N으로 재부여합니다.
+                    요청 pinnedOrder는 pinned=true 항목의 상대적 우선순위로만 사용됩니다.
                     """
     )
     @RequestBody(

--- a/src/main/java/com/example/cowmjucraft/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/repository/ProjectRepository.java
@@ -21,6 +21,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 """)
     List<Project> findAllOrderedForPublic();
 
-    @Query("select p.id from Project p where p.pinned = true")
-    List<Long> findPinnedIds();
+    @Query("select p from Project p where p.pinned = true")
+    List<Project> findAllPinned();
 }


### PR DESCRIPTION
요약

프로젝트 고정(pinned) 및 정렬 순서를 일괄 변경할 수 있도록
기존 /admin/projects/order API의 로직과 검증 정책을 개선했습니다.

기존에는 pinned 집합 변경(고정 추가/해제)이 불가능했으나,
이번 변경으로 핀 토글 + 순서 재정렬을 동시에 처리할 수 있습니다.

⸻

작업 내용
	•	프로젝트 pinned 집합 변경(추가/해제) 허용
	•	unpinned → pinned / pinned → unpinned 전환 가능하도록 로직 수정
	•	pinnedOrder 서버 재부여 로직 추가
	•	요청된 pinnedOrder는 상대적 우선순위로만 사용
	•	최종 pinnedOrder는 서버에서 1..N으로 일괄 재할당
	•	pinned=false 시 pinnedOrder 정리
	•	pinned 해제 시 pinnedOrder가 남지 않도록 데이터 정합성 보장
	•	정렬 변경 요청 검증 보강
	•	items null 방어
	•	items 내 null element 방어
	•	중복 projectId 검증
	•	pinned/manualOrder 상호 배타 규칙 강화
