### PR TITLE
feat: 상품 한줄 설명(summary) 필드 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
@@ -74,6 +74,7 @@ public interface AdminItemControllerDocs {
                             value = """
                                     {
                                       "name": "명지공방 머그컵",
+                                      "summary": "캠퍼스 감성을 담은 데일리 머그컵",
                                       "description": "캠퍼스 감성을 담은 머그컵입니다.",
                                       "price": 12000,
                                       "saleType": "GROUPBUY",
@@ -103,6 +104,7 @@ public interface AdminItemControllerDocs {
                                                 "id": 1,
                                                 "projectId": 10,
                                                 "name": "명지공방 머그컵",
+                                                "summary": "캠퍼스 감성을 담은 데일리 머그컵",
                                                 "description": "캠퍼스 감성을 담은 머그컵입니다.",
                                                 "price": 12000,
                                                 "saleType": "GROUPBUY",
@@ -142,6 +144,7 @@ public interface AdminItemControllerDocs {
                             value = """
                                     {
                                       "name": "명지공방 머그컵",
+                                      "summary": "캠퍼스 감성을 담은 데일리 머그컵",
                                       "description": "캠퍼스 감성을 담은 머그컵입니다.",
                                       "price": 11000,
                                       "saleType": "NORMAL",

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemControllerDocs.java
@@ -37,6 +37,7 @@ public interface ItemControllerDocs {
                                                 {
                                                   "id": 1,
                                                   "name": "명지공방 머그컵",
+                                                  "summary": "캠퍼스 감성을 담은 데일리 머그컵",
                                                   "price": 12000,
                                                   "saleType": "GROUPBUY",
                                                   "status": "OPEN",
@@ -81,6 +82,7 @@ public interface ItemControllerDocs {
                                                 "id": 1,
                                                 "projectId": 10,
                                                 "name": "명지공방 머그컵",
+                                                "summary": "캠퍼스 감성을 담은 데일리 머그컵",
                                                 "description": "캠퍼스 감성을 담은 머그컵입니다.",
                                                 "price": 12000,
                                                 "saleType": "GROUPBUY",

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "프로젝트 물품 생성 요청")
 public record AdminProjectItemCreateRequestDto(
@@ -13,6 +14,10 @@ public record AdminProjectItemCreateRequestDto(
         @NotBlank
         @Schema(description = "물품명", example = "명지공방 머그컵")
         String name,
+
+        @Size(max = 200)
+        @Schema(description = "물품 한줄 설명", example = "캠퍼스 감성을 담은 데일리 머그컵")
+        String summary,
 
         @NotBlank
         @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "프로젝트 물품 수정 요청")
 public record AdminProjectItemUpdateRequestDto(
@@ -13,6 +14,10 @@ public record AdminProjectItemUpdateRequestDto(
         @NotBlank
         @Schema(description = "물품명", example = "명지공방 머그컵")
         String name,
+
+        @Size(max = 200)
+        @Schema(description = "물품 한줄 설명", example = "캠퍼스 감성을 담은 데일리 머그컵")
+        String summary,
 
         @NotBlank
         @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemDetailResponseDto.java
@@ -19,6 +19,9 @@ public record AdminProjectItemDetailResponseDto(
         @Schema(description = "물품명", example = "명지공방 머그컵")
         String name,
 
+        @Schema(description = "물품 한줄 설명", example = "캠퍼스 감성을 담은 데일리 머그컵")
+        String summary,
+
         @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
         String description,
 

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemResponseDto.java
@@ -18,6 +18,9 @@ public record AdminProjectItemResponseDto(
         @Schema(description = "물품명", example = "명지공방 머그컵")
         String name,
 
+        @Schema(description = "물품 한줄 설명", example = "캠퍼스 감성을 담은 데일리 머그컵")
+        String summary,
+
         @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
         String description,
 

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemDetailResponseDto.java
@@ -18,6 +18,9 @@ public record ProjectItemDetailResponseDto(
         @Schema(description = "물품명", example = "명지공방 머그컵")
         String name,
 
+        @Schema(description = "물품 한줄 설명", example = "캠퍼스 감성을 담은 데일리 머그컵")
+        String summary,
+
         @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
         String description,
 

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemListResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemListResponseDto.java
@@ -14,6 +14,9 @@ public record ProjectItemListResponseDto(
         @Schema(description = "물품명", example = "명지공방 머그컵")
         String name,
 
+        @Schema(description = "물품 한줄 설명", example = "캠퍼스 감성을 담은 데일리 머그컵")
+        String summary,
+
         @Schema(description = "가격", example = "12000")
         int price,
 

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
@@ -35,6 +35,9 @@ public class ProjectItem extends BaseTimeEntity {
     @Column(length = 100, nullable = false)
     private String name;
 
+    @Column(length = 200)
+    private String summary;
+
     @Lob
     @Column(nullable = false)
     private String description;
@@ -62,6 +65,7 @@ public class ProjectItem extends BaseTimeEntity {
     public ProjectItem(
             Project project,
             String name,
+            String summary,
             String description,
             int price,
             ItemSaleType saleType,
@@ -72,6 +76,7 @@ public class ProjectItem extends BaseTimeEntity {
     ) {
         this.project = project;
         this.name = name;
+        this.summary = summary;
         this.description = description;
         this.price = price;
         this.saleType = saleType;
@@ -83,6 +88,7 @@ public class ProjectItem extends BaseTimeEntity {
 
     public void update(
             String name,
+            String summary,
             String description,
             int price,
             ItemSaleType saleType,
@@ -92,6 +98,7 @@ public class ProjectItem extends BaseTimeEntity {
             int fundedQty
     ) {
         this.name = name;
+        this.summary = summary;
         this.description = description;
         this.price = price;
         this.saleType = saleType;

--- a/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
@@ -51,6 +51,7 @@ public class AdminItemService {
         ProjectItem item = new ProjectItem(
                 project,
                 request.name(),
+                request.summary(),
                 request.description(),
                 request.price(),
                 request.saleType(),
@@ -72,6 +73,7 @@ public class AdminItemService {
         NormalizedItemRequest normalized = normalizeUpdate(request);
         item.update(
                 request.name(),
+                request.summary(),
                 request.description(),
                 request.price(),
                 request.saleType(),
@@ -335,6 +337,7 @@ public class AdminItemService {
                 item.getId(),
                 item.getProject().getId(),
                 item.getName(),
+                item.getSummary(),
                 item.getDescription(),
                 item.getPrice(),
                 item.getSaleType(),
@@ -360,6 +363,7 @@ public class AdminItemService {
                 item.getId(),
                 item.getProject().getId(),
                 item.getName(),
+                item.getSummary(),
                 item.getDescription(),
                 item.getPrice(),
                 item.getSaleType(),

--- a/src/main/java/com/example/cowmjucraft/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/service/ItemService.java
@@ -79,6 +79,7 @@ public class ItemService {
         return new ProjectItemListResponseDto(
                 item.getId(),
                 item.getName(),
+                item.getSummary(),
                 item.getPrice(),
                 item.getSaleType(),
                 item.getStatus(),
@@ -101,6 +102,7 @@ public class ItemService {
                 item.getId(),
                 item.getProject().getId(),
                 item.getName(),
+                item.getSummary(),
                 item.getDescription(),
                 item.getPrice(),
                 item.getSaleType(),


### PR DESCRIPTION
# 요약
상품에 한줄 설명(summary) 필드를 추가했습니다.

# 작업 내용
- ProjectItem 엔티티에 summary 컬럼 추가
- 관리자 상품 생성/수정 API에서 summary 입력 및 수정 가능하도록 처리
- 관리자/공개 상품 조회 응답에 summary 필드 노출
- Swagger 요청/응답 예시 및 스키마 업데이트

# 타 직군 전달 사항
- 상품 카드/상세 화면에서 summary 필드 사용 가능
