### PR TITLE
fix: ProjectItem description 컬럼 MEDIUMTEXT로 고정

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
@@ -39,7 +39,7 @@ public class ProjectItem extends BaseTimeEntity {
     private String summary;
 
     @Lob
-    @Column(nullable = false)
+    @Column(columnDefinition = "MEDIUMTEXT", nullable = false)
     private String description;
 
     @Column(nullable = false)


### PR DESCRIPTION
# 요약

ProjectItem 엔티티의 description 컬럼을 MEDIUMTEXT로 고정하여  
Hibernate 스키마 자동 업데이트 시 컬럼 축소(tinytext) 시도가 발생하지 않도록 수정했습니다.

# 작업 내용

- ProjectItem.description 필드에 `columnDefinition = "MEDIUMTEXT"` 적용
  - 한글/장문 텍스트 사용을 고려해 충분한 컬럼 크기 확보
  - Hibernate가 컬럼 타입을 자동 판단하며 축소 ALTER를 시도하던 문제 방지