### PR TITLE
feat: 장바구니, 바로구매 기능 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/cart/controller/CartController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/cart/controller/CartController.java
@@ -1,0 +1,80 @@
+package com.example.cowmjucraft.domain.cart.controller;
+
+import com.example.cowmjucraft.domain.cart.dto.request.CartItemCreateRequestDto;
+import com.example.cowmjucraft.domain.cart.dto.request.CartItemQuantityUpdateRequestDto;
+import com.example.cowmjucraft.domain.cart.dto.response.CartSummaryResponseDto;
+import com.example.cowmjucraft.domain.cart.service.CartService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/mypage/cart")
+public class CartController implements CartControllerDocs {
+
+    private final CartService cartService;
+
+    @GetMapping
+    @Override
+    public ApiResult<CartSummaryResponseDto> getCart(@AuthenticationPrincipal String memberId) {
+        return ApiResult.success(SuccessType.SUCCESS, cartService.getCart(parseMemberId(memberId)));
+    }
+
+    @PostMapping
+    @Override
+    public ApiResult<CartSummaryResponseDto> addCartItem(
+            @AuthenticationPrincipal String memberId,
+            @Valid @RequestBody CartItemCreateRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.SUCCESS, cartService.addCartItem(parseMemberId(memberId), request));
+    }
+
+    @PutMapping("/{cartItemId}")
+    @Override
+    public ApiResult<CartSummaryResponseDto> updateCartItemQuantity(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable Long cartItemId,
+            @Valid @RequestBody CartItemQuantityUpdateRequestDto request
+    ) {
+        return ApiResult.success(
+                SuccessType.SUCCESS,
+                cartService.updateCartItemQuantity(parseMemberId(memberId), cartItemId, request)
+        );
+    }
+
+    @DeleteMapping("/{cartItemId}")
+    @Override
+    public ApiResult<?> removeCartItem(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable Long cartItemId
+    ) {
+        cartService.removeCartItem(parseMemberId(memberId), cartItemId);
+        return ApiResult.success(SuccessType.NO_CONTENT);
+    }
+
+    @DeleteMapping
+    @Override
+    public ApiResult<?> clearCart(@AuthenticationPrincipal String memberId) {
+        cartService.clearCart(parseMemberId(memberId));
+        return ApiResult.success(SuccessType.NO_CONTENT);
+    }
+
+    private Long parseMemberId(String principal) {
+        try {
+            return Long.valueOf(principal);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid member id");
+        }
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/cart/controller/CartControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/cart/controller/CartControllerDocs.java
@@ -1,0 +1,73 @@
+package com.example.cowmjucraft.domain.cart.controller;
+
+import com.example.cowmjucraft.domain.cart.dto.request.CartItemCreateRequestDto;
+import com.example.cowmjucraft.domain.cart.dto.request.CartItemQuantityUpdateRequestDto;
+import com.example.cowmjucraft.domain.cart.dto.response.CartSummaryResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Cart", description = "장바구니 API")
+public interface CartControllerDocs {
+
+    @Operation(summary = "장바구니 조회", description = "현재 로그인한 사용자의 장바구니를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    ApiResult<CartSummaryResponseDto> getCart(
+            @Parameter(hidden = true)
+            String memberId
+    );
+
+    @Operation(summary = "장바구니 아이템 추가", description = "물품을 장바구니에 추가합니다. 기존 아이템이면 수량이 누적됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "추가 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))),
+            @ApiResponse(responseCode = "404", description = "물품 없음")
+    })
+    ApiResult<CartSummaryResponseDto> addCartItem(
+            @Parameter(hidden = true)
+            String memberId,
+            @Valid @RequestBody CartItemCreateRequestDto request
+    );
+
+    @Operation(summary = "장바구니 아이템 수량 수정", description = "장바구니 아이템의 수량을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))),
+            @ApiResponse(responseCode = "404", description = "장바구니 아이템 없음")
+    })
+    ApiResult<CartSummaryResponseDto> updateCartItemQuantity(
+            @Parameter(hidden = true)
+            String memberId,
+            @Parameter(description = "장바구니 아이템 ID", example = "10")
+            @PathVariable Long cartItemId,
+            @Valid @RequestBody CartItemQuantityUpdateRequestDto request
+    );
+
+    @Operation(summary = "장바구니 아이템 삭제", description = "선택한 장바구니 아이템을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "장바구니 아이템 없음")
+    })
+    ApiResult<?> removeCartItem(
+            @Parameter(hidden = true)
+            String memberId,
+            @Parameter(description = "장바구니 아이템 ID", example = "10")
+            @PathVariable Long cartItemId
+    );
+
+    @Operation(summary = "장바구니 비우기", description = "현재 로그인한 사용자의 장바구니를 비웁니다.")
+    @ApiResponse(responseCode = "204", description = "비우기 성공")
+    ApiResult<?> clearCart(
+            @Parameter(hidden = true)
+            String memberId
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/cart/dto/request/CartItemCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/cart/dto/request/CartItemCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.cowmjucraft.domain.cart.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "장바구니 아이템 추가 요청 DTO")
+public record CartItemCreateRequestDto(
+
+        @NotNull
+        @Schema(description = "물품 ID", example = "1")
+        Long itemId,
+
+        @NotNull
+        @Min(1)
+        @Schema(description = "수량", example = "2")
+        Integer quantity
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/cart/dto/request/CartItemQuantityUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/cart/dto/request/CartItemQuantityUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.cowmjucraft.domain.cart.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "장바구니 수량 수정 요청 DTO")
+public record CartItemQuantityUpdateRequestDto(
+
+        @NotNull
+        @Min(1)
+        @Schema(description = "수량", example = "3")
+        Integer quantity
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/cart/dto/response/CartItemResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/cart/dto/response/CartItemResponseDto.java
@@ -1,0 +1,37 @@
+package com.example.cowmjucraft.domain.cart.dto.response;
+
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "장바구니 아이템 응답 DTO")
+public record CartItemResponseDto(
+
+        @Schema(description = "장바구니 아이템 ID", example = "10")
+        Long cartItemId,
+
+        @Schema(description = "물품 ID", example = "1")
+        Long itemId,
+
+        @Schema(description = "물품명", example = "명지공방 머그컵")
+        String itemName,
+
+        @Schema(description = "판매 유형", example = "NORMAL")
+        ItemSaleType saleType,
+
+        @Schema(description = "판매 상태", example = "OPEN")
+        ItemStatus status,
+
+        @Schema(description = "대표 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png")
+        String thumbnailUrl,
+
+        @Schema(description = "단가", example = "12000")
+        int unitPrice,
+
+        @Schema(description = "수량", example = "2")
+        int quantity,
+
+        @Schema(description = "소계", example = "24000")
+        int linePrice
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/cart/dto/response/CartSummaryResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/cart/dto/response/CartSummaryResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.cowmjucraft.domain.cart.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "장바구니 조회 응답 DTO")
+public record CartSummaryResponseDto(
+
+        @Schema(description = "총 아이템 수", example = "2")
+        int itemCount,
+
+        @Schema(description = "총 수량", example = "3")
+        int totalQuantity,
+
+        @Schema(description = "총 금액", example = "36000")
+        int totalPrice,
+
+        @Schema(description = "장바구니 아이템 목록")
+        List<CartItemResponseDto> items
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/cart/entity/CartItem.java
@@ -1,0 +1,65 @@
+package com.example.cowmjucraft.domain.cart.entity;
+
+import com.example.cowmjucraft.domain.accounts.user.entity.Member;
+import com.example.cowmjucraft.domain.common.BaseTimeEntity;
+import com.example.cowmjucraft.domain.item.entity.ProjectItem;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "cart_items",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"member_id", "item_id"})
+        }
+)
+public class CartItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private ProjectItem item;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    public CartItem(Member member, ProjectItem item, int quantity) {
+        this.member = member;
+        this.item = item;
+        this.quantity = quantity;
+    }
+
+    public void increaseQuantity(int amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+        this.quantity += amount;
+    }
+
+    public void changeQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("quantity must be positive");
+        }
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/cart/repository/CartItemRepository.java
@@ -1,0 +1,20 @@
+package com.example.cowmjucraft.domain.cart.repository;
+
+import com.example.cowmjucraft.domain.cart.entity.CartItem;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+    @EntityGraph(attributePaths = {"item"})
+    List<CartItem> findByMemberIdOrderByCreatedAtDescIdDesc(Long memberId);
+
+    @EntityGraph(attributePaths = {"item"})
+    Optional<CartItem> findByIdAndMemberId(Long id, Long memberId);
+
+    Optional<CartItem> findByMemberIdAndItemId(Long memberId, Long itemId);
+
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/cowmjucraft/domain/cart/service/CartService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/cart/service/CartService.java
@@ -1,0 +1,163 @@
+package com.example.cowmjucraft.domain.cart.service;
+
+import com.example.cowmjucraft.domain.accounts.user.entity.Member;
+import com.example.cowmjucraft.domain.accounts.user.repository.MemberRepository;
+import com.example.cowmjucraft.domain.cart.dto.request.CartItemCreateRequestDto;
+import com.example.cowmjucraft.domain.cart.dto.request.CartItemQuantityUpdateRequestDto;
+import com.example.cowmjucraft.domain.cart.dto.response.CartItemResponseDto;
+import com.example.cowmjucraft.domain.cart.dto.response.CartSummaryResponseDto;
+import com.example.cowmjucraft.domain.cart.entity.CartItem;
+import com.example.cowmjucraft.domain.cart.repository.CartItemRepository;
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.example.cowmjucraft.domain.item.entity.ProjectItem;
+import com.example.cowmjucraft.domain.item.repository.ProjectItemRepository;
+import com.example.cowmjucraft.global.cloud.S3PresignFacade;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@RequiredArgsConstructor
+@Service
+public class CartService {
+
+    private final MemberRepository memberRepository;
+    private final ProjectItemRepository projectItemRepository;
+    private final CartItemRepository cartItemRepository;
+    private final S3PresignFacade s3PresignFacade;
+
+    @Transactional(readOnly = true)
+    public CartSummaryResponseDto getCart(Long memberId) {
+        getMember(memberId);
+
+        List<CartItem> cartItems = cartItemRepository.findByMemberIdOrderByCreatedAtDescIdDesc(memberId);
+        Set<String> thumbnailKeys = new LinkedHashSet<>();
+        for (CartItem cartItem : cartItems) {
+            addIfValidKey(thumbnailKeys, cartItem.getItem().getThumbnailKey());
+        }
+        Map<String, String> urls = presignGetSafely(thumbnailKeys);
+
+        List<CartItemResponseDto> items = new ArrayList<>();
+        int totalQuantity = 0;
+        int totalPrice = 0;
+
+        for (CartItem cartItem : cartItems) {
+            ProjectItem item = cartItem.getItem();
+            int linePrice = item.getPrice() * cartItem.getQuantity();
+            totalQuantity += cartItem.getQuantity();
+            totalPrice += linePrice;
+
+            items.add(new CartItemResponseDto(
+                    cartItem.getId(),
+                    item.getId(),
+                    item.getName(),
+                    item.getSaleType(),
+                    item.getStatus(),
+                    resolveUrl(urls, item.getThumbnailKey()),
+                    item.getPrice(),
+                    cartItem.getQuantity(),
+                    linePrice
+            ));
+        }
+
+        return new CartSummaryResponseDto(items.size(), totalQuantity, totalPrice, items);
+    }
+
+    @Transactional
+    public CartSummaryResponseDto addCartItem(Long memberId, CartItemCreateRequestDto request) {
+        Member member = getMember(memberId);
+        ProjectItem item = getItem(request.itemId());
+        validatePurchasable(item, request.quantity());
+
+        CartItem cartItem = cartItemRepository.findByMemberIdAndItemId(memberId, item.getId())
+                .orElseGet(() -> new CartItem(member, item, 0));
+
+        cartItem.increaseQuantity(request.quantity());
+        cartItemRepository.save(cartItem);
+
+        return getCart(memberId);
+    }
+
+    @Transactional
+    public CartSummaryResponseDto updateCartItemQuantity(
+            Long memberId,
+            Long cartItemId,
+            CartItemQuantityUpdateRequestDto request
+    ) {
+        CartItem cartItem = cartItemRepository.findByIdAndMemberId(cartItemId, memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "cart item not found"));
+
+        validatePurchasable(cartItem.getItem(), request.quantity());
+        cartItem.changeQuantity(request.quantity());
+
+        return getCart(memberId);
+    }
+
+    @Transactional
+    public void removeCartItem(Long memberId, Long cartItemId) {
+        CartItem cartItem = cartItemRepository.findByIdAndMemberId(cartItemId, memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "cart item not found"));
+        cartItemRepository.delete(cartItem);
+    }
+
+    @Transactional
+    public void clearCart(Long memberId) {
+        getMember(memberId);
+        cartItemRepository.deleteByMemberId(memberId);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found"));
+    }
+
+    private ProjectItem getItem(Long itemId) {
+        return projectItemRepository.findById(itemId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "item not found"));
+    }
+
+    private void validatePurchasable(ProjectItem item, int quantity) {
+        if (item.getStatus() != ItemStatus.OPEN) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "item is not open for purchase");
+        }
+        if (item.getSaleType() == ItemSaleType.GROUPBUY && item.getTargetQty() != null) {
+            int remaining = Math.max(item.getTargetQty() - item.getFundedQty(), 0);
+            if (remaining < quantity) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "requested quantity exceeds remaining groupbuy quantity");
+            }
+        }
+    }
+
+    private Map<String, String> presignGetSafely(Set<String> keys) {
+        try {
+            return keys == null || keys.isEmpty()
+                    ? Map.of()
+                    : s3PresignFacade.presignGet(new ArrayList<>(keys));
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+    private String resolveUrl(Map<String, String> urls, String key) {
+        String normalized = toNonBlankString(key);
+        return normalized == null ? null : urls.get(normalized);
+    }
+
+    private void addIfValidKey(Set<String> keys, String value) {
+        String normalized = toNonBlankString(value);
+        if (normalized != null) {
+            keys.add(normalized);
+        }
+    }
+
+    private String toNonBlankString(String value) {
+        return value == null || value.trim().isEmpty() ? null : value.trim();
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
@@ -111,4 +111,11 @@ public class ProjectItem extends BaseTimeEntity {
     public void clearThumbnail() {
         this.thumbnailKey = null;
     }
+
+    public void increaseFundedQty(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("quantity must be positive");
+        }
+        this.fundedQty += quantity;
+    }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/order/controller/PurchaseOrderController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/controller/PurchaseOrderController.java
@@ -1,0 +1,52 @@
+package com.example.cowmjucraft.domain.order.controller;
+
+import com.example.cowmjucraft.domain.order.dto.request.BuyNowRequestDto;
+import com.example.cowmjucraft.domain.order.dto.request.CartCheckoutRequestDto;
+import com.example.cowmjucraft.domain.order.dto.response.PurchaseOrderCreateResponseDto;
+import com.example.cowmjucraft.domain.order.service.PurchaseOrderService;
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.SuccessType;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/mypage/orders")
+public class PurchaseOrderController implements PurchaseOrderControllerDocs {
+
+    private final PurchaseOrderService purchaseOrderService;
+
+    @PostMapping("/buy-now")
+    @Override
+    public ApiResult<PurchaseOrderCreateResponseDto> buyNow(
+            @AuthenticationPrincipal String memberId,
+            @Valid @RequestBody BuyNowRequestDto request
+    ) {
+        return ApiResult.success(SuccessType.CREATED, purchaseOrderService.buyNow(parseMemberId(memberId), request));
+    }
+
+    @PostMapping("/checkout-cart")
+    @Override
+    public ApiResult<PurchaseOrderCreateResponseDto> checkoutCart(
+            @AuthenticationPrincipal String memberId,
+            @Valid @RequestBody CartCheckoutRequestDto request
+    ) {
+        return ApiResult.success(
+                SuccessType.CREATED,
+                purchaseOrderService.checkoutCart(parseMemberId(memberId), request)
+        );
+    }
+
+    private Long parseMemberId(String principal) {
+        try {
+            return Long.valueOf(principal);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid member id");
+        }
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/controller/PurchaseOrderControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/controller/PurchaseOrderControllerDocs.java
@@ -1,0 +1,41 @@
+package com.example.cowmjucraft.domain.order.controller;
+
+import com.example.cowmjucraft.domain.order.dto.request.BuyNowRequestDto;
+import com.example.cowmjucraft.domain.order.dto.request.CartCheckoutRequestDto;
+import com.example.cowmjucraft.domain.order.dto.response.PurchaseOrderCreateResponseDto;
+import com.example.cowmjucraft.global.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Order", description = "주문 API")
+public interface PurchaseOrderControllerDocs {
+
+    @Operation(summary = "바로 구매", description = "장바구니를 거치지 않고 물품을 바로 주문합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "주문 생성 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))),
+            @ApiResponse(responseCode = "404", description = "물품 없음")
+    })
+    ApiResult<PurchaseOrderCreateResponseDto> buyNow(
+            @Parameter(hidden = true)
+            String memberId,
+            @Valid @RequestBody BuyNowRequestDto request
+    );
+
+    @Operation(summary = "장바구니 주문", description = "선택한 장바구니 아이템들로 주문을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "주문 생성 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))),
+            @ApiResponse(responseCode = "404", description = "장바구니 아이템 없음")
+    })
+    ApiResult<PurchaseOrderCreateResponseDto> checkoutCart(
+            @Parameter(hidden = true)
+            String memberId,
+            @Valid @RequestBody CartCheckoutRequestDto request
+    );
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/dto/request/BuyNowRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/dto/request/BuyNowRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.cowmjucraft.domain.order.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "바로 구매 요청 DTO")
+public record BuyNowRequestDto(
+
+        @NotNull
+        @Schema(description = "물품 ID", example = "1")
+        Long itemId,
+
+        @NotNull
+        @Min(1)
+        @Schema(description = "수량", example = "1")
+        Integer quantity
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/dto/request/CartCheckoutRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/dto/request/CartCheckoutRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.cowmjucraft.domain.order.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+@Schema(description = "장바구니 결제 요청 DTO")
+public record CartCheckoutRequestDto(
+
+        @NotNull
+        @NotEmpty
+        @Schema(description = "결제할 장바구니 아이템 ID 목록", example = "[10, 11]")
+        List<Long> cartItemIds
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/dto/response/PurchaseOrderCreateResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/dto/response/PurchaseOrderCreateResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.cowmjucraft.domain.order.dto.response;
+
+import com.example.cowmjucraft.domain.order.entity.PurchaseOrderStatus;
+import com.example.cowmjucraft.domain.order.entity.PurchaseOrderType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "주문 생성 응답 DTO")
+public record PurchaseOrderCreateResponseDto(
+
+        @Schema(description = "주문 ID", example = "100")
+        Long orderId,
+
+        @Schema(description = "주문 유형", example = "BUY_NOW")
+        PurchaseOrderType orderType,
+
+        @Schema(description = "주문 상태", example = "CREATED")
+        PurchaseOrderStatus status,
+
+        @Schema(description = "총 결제 금액", example = "36000")
+        int totalPrice,
+
+        @Schema(description = "주문 생성 시각")
+        LocalDateTime orderedAt,
+
+        @Schema(description = "주문 항목 목록")
+        List<PurchaseOrderLineResponseDto> lines
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/dto/response/PurchaseOrderLineResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/dto/response/PurchaseOrderLineResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.cowmjucraft.domain.order.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "주문 라인 응답 DTO")
+public record PurchaseOrderLineResponseDto(
+
+        @Schema(description = "물품 ID", example = "1")
+        Long itemId,
+
+        @Schema(description = "물품명", example = "명지공방 머그컵")
+        String itemName,
+
+        @Schema(description = "단가", example = "12000")
+        int unitPrice,
+
+        @Schema(description = "수량", example = "2")
+        int quantity,
+
+        @Schema(description = "소계", example = "24000")
+        int linePrice
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/entity/PurchaseOrder.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/entity/PurchaseOrder.java
@@ -1,0 +1,63 @@
+package com.example.cowmjucraft.domain.order.entity;
+
+import com.example.cowmjucraft.domain.accounts.user.entity.Member;
+import com.example.cowmjucraft.domain.common.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "purchase_orders")
+public class PurchaseOrder extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PurchaseOrderType orderType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PurchaseOrderStatus status;
+
+    @Column(nullable = false)
+    private int totalPrice;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PurchaseOrderItem> items = new ArrayList<>();
+
+    public PurchaseOrder(Member member, PurchaseOrderType orderType) {
+        this.member = member;
+        this.orderType = orderType;
+        this.status = PurchaseOrderStatus.CREATED;
+        this.totalPrice = 0;
+    }
+
+    public void addItem(PurchaseOrderItem orderItem) {
+        this.items.add(orderItem);
+        this.totalPrice += orderItem.getLinePrice();
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/entity/PurchaseOrderItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/entity/PurchaseOrderItem.java
@@ -1,0 +1,55 @@
+package com.example.cowmjucraft.domain.order.entity;
+
+import com.example.cowmjucraft.domain.item.entity.ProjectItem;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "purchase_order_items")
+public class PurchaseOrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private PurchaseOrder order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private ProjectItem item;
+
+    @Column(nullable = false, length = 100)
+    private String itemName;
+
+    @Column(nullable = false)
+    private int unitPrice;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(nullable = false)
+    private int linePrice;
+
+    public PurchaseOrderItem(PurchaseOrder order, ProjectItem item, int quantity) {
+        this.order = order;
+        this.item = item;
+        this.itemName = item.getName();
+        this.unitPrice = item.getPrice();
+        this.quantity = quantity;
+        this.linePrice = item.getPrice() * quantity;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/entity/PurchaseOrderStatus.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/entity/PurchaseOrderStatus.java
@@ -1,0 +1,5 @@
+package com.example.cowmjucraft.domain.order.entity;
+
+public enum PurchaseOrderStatus {
+    CREATED
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/entity/PurchaseOrderType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/entity/PurchaseOrderType.java
@@ -1,0 +1,6 @@
+package com.example.cowmjucraft.domain.order.entity;
+
+public enum PurchaseOrderType {
+    BUY_NOW,
+    CART
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/repository/PurchaseOrderItemRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/repository/PurchaseOrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.cowmjucraft.domain.order.repository;
+
+import com.example.cowmjucraft.domain.order.entity.PurchaseOrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PurchaseOrderItemRepository extends JpaRepository<PurchaseOrderItem, Long> {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/repository/PurchaseOrderRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/repository/PurchaseOrderRepository.java
@@ -1,0 +1,7 @@
+package com.example.cowmjucraft.domain.order.repository;
+
+import com.example.cowmjucraft.domain.order.entity.PurchaseOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Long> {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/PurchaseOrderService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/PurchaseOrderService.java
@@ -1,0 +1,135 @@
+package com.example.cowmjucraft.domain.order.service;
+
+import com.example.cowmjucraft.domain.accounts.user.entity.Member;
+import com.example.cowmjucraft.domain.accounts.user.repository.MemberRepository;
+import com.example.cowmjucraft.domain.cart.entity.CartItem;
+import com.example.cowmjucraft.domain.cart.repository.CartItemRepository;
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.example.cowmjucraft.domain.item.entity.ProjectItem;
+import com.example.cowmjucraft.domain.item.repository.ProjectItemRepository;
+import com.example.cowmjucraft.domain.order.dto.request.BuyNowRequestDto;
+import com.example.cowmjucraft.domain.order.dto.request.CartCheckoutRequestDto;
+import com.example.cowmjucraft.domain.order.dto.response.PurchaseOrderCreateResponseDto;
+import com.example.cowmjucraft.domain.order.dto.response.PurchaseOrderLineResponseDto;
+import com.example.cowmjucraft.domain.order.entity.PurchaseOrder;
+import com.example.cowmjucraft.domain.order.entity.PurchaseOrderItem;
+import com.example.cowmjucraft.domain.order.entity.PurchaseOrderType;
+import com.example.cowmjucraft.domain.order.repository.PurchaseOrderRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@RequiredArgsConstructor
+@Service
+public class PurchaseOrderService {
+
+    private final MemberRepository memberRepository;
+    private final ProjectItemRepository projectItemRepository;
+    private final CartItemRepository cartItemRepository;
+    private final PurchaseOrderRepository purchaseOrderRepository;
+
+    @Transactional
+    public PurchaseOrderCreateResponseDto buyNow(Long memberId, BuyNowRequestDto request) {
+        Member member = getMember(memberId);
+        ProjectItem item = getItem(request.itemId());
+        validatePurchasable(item, request.quantity());
+
+        PurchaseOrder order = new PurchaseOrder(member, PurchaseOrderType.BUY_NOW);
+        addOrderLine(order, item, request.quantity());
+        PurchaseOrder saved = purchaseOrderRepository.save(order);
+
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public PurchaseOrderCreateResponseDto checkoutCart(Long memberId, CartCheckoutRequestDto request) {
+        Member member = getMember(memberId);
+        List<CartItem> selectedCartItems = findCartItems(memberId, request.cartItemIds());
+        if (selectedCartItems.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "no cart items selected");
+        }
+
+        PurchaseOrder order = new PurchaseOrder(member, PurchaseOrderType.CART);
+        for (CartItem cartItem : selectedCartItems) {
+            addOrderLine(order, cartItem.getItem(), cartItem.getQuantity());
+        }
+
+        PurchaseOrder saved = purchaseOrderRepository.save(order);
+        cartItemRepository.deleteAll(selectedCartItems);
+
+        return toResponse(saved);
+    }
+
+    private List<CartItem> findCartItems(Long memberId, List<Long> cartItemIds) {
+        Set<Long> deduplicatedIds = new LinkedHashSet<>(cartItemIds);
+        List<CartItem> selectedCartItems = new ArrayList<>();
+        for (Long cartItemId : deduplicatedIds) {
+            CartItem cartItem = cartItemRepository.findByIdAndMemberId(cartItemId, memberId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "cart item not found: " + cartItemId));
+            selectedCartItems.add(cartItem);
+        }
+        return selectedCartItems;
+    }
+
+    private void addOrderLine(PurchaseOrder order, ProjectItem item, int quantity) {
+        validatePurchasable(item, quantity);
+
+        PurchaseOrderItem orderItem = new PurchaseOrderItem(order, item, quantity);
+        order.addItem(orderItem);
+
+        if (item.getSaleType() == ItemSaleType.GROUPBUY) {
+            item.increaseFundedQty(quantity);
+        }
+    }
+
+    private PurchaseOrderCreateResponseDto toResponse(PurchaseOrder order) {
+        List<PurchaseOrderLineResponseDto> lines = order.getItems().stream()
+                .map(item -> new PurchaseOrderLineResponseDto(
+                        item.getItem().getId(),
+                        item.getItemName(),
+                        item.getUnitPrice(),
+                        item.getQuantity(),
+                        item.getLinePrice()
+                ))
+                .toList();
+
+        return new PurchaseOrderCreateResponseDto(
+                order.getId(),
+                order.getOrderType(),
+                order.getStatus(),
+                order.getTotalPrice(),
+                order.getCreatedAt(),
+                lines
+        );
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found"));
+    }
+
+    private ProjectItem getItem(Long itemId) {
+        return projectItemRepository.findById(itemId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "item not found"));
+    }
+
+    private void validatePurchasable(ProjectItem item, int quantity) {
+        if (item.getStatus() != ItemStatus.OPEN) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "item is not open for purchase");
+        }
+
+        if (item.getSaleType() == ItemSaleType.GROUPBUY && item.getTargetQty() != null) {
+            int remaining = Math.max(item.getTargetQty() - item.getFundedQty(), 0);
+            if (remaining < quantity) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "requested quantity exceeds remaining groupbuy quantity");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 요약
장바구니 조회/추가/수정/삭제 API와 바로구매, 장바구니 주문 생성 API를 추가하고 공동구매 수량 집계가 주문 시 반영되도록 도메인을 확장했습니다.

# 작업 내용
- 장바구니 도메인(CartItem) 및 DTO/서비스/컨트롤러/Swagger 문서 추가
- 주문 도메인(PurchaseOrder, PurchaseOrderItem) 및 DTO/서비스/컨트롤러/Swagger 문서 추가, 바로구매/장바구니 주문 생성 흐름 구현
- 공동구매 주문 시 fundedQty 증가 로직 추가 및 구매 가능 상태/잔여수량 검증 적용

# 기타 (논의하고 싶은 부분)
없음

# 타 직군 전달 사항
장바구니 API:
GET /api/mypage/cart
POST /api/mypage/cart (itemId, quantity)
PUT /api/mypage/cart/{cartItemId} (quantity)
DELETE /api/mypage/cart/{cartItemId}
DELETE /api/mypage/cart
주문 API:
POST /api/mypage/orders/buy-now (itemId, quantity)
POST /api/mypage/orders/checkout-cart (cartItemIds)
응답: 주문 생성 시 orderId, orderType, status, totalPrice, orderedAt, lines(아이템별 금액/수량)