### PR TITLE
feat: 저널 파일 업로드 및 다운로드 기능 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
@@ -10,6 +10,7 @@ import com.example.cowmjucraft.domain.item.dto.response.AdminItemPresignPutBatch
 import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemDetailResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemJournalPresignGetResponseDto;
 import com.example.cowmjucraft.domain.item.service.AdminItemService;
 import com.example.cowmjucraft.global.response.ApiResult;
 import com.example.cowmjucraft.global.response.type.SuccessType;
@@ -91,6 +92,18 @@ public class AdminItemController implements AdminItemControllerDocs {
         );
     }
 
+    @PostMapping("/projects/{projectId}/journals/presign-put")
+    @Override
+    public ApiResult<AdminItemPresignPutBatchResponseDto> presignJournalFile(
+            @PathVariable Long projectId,
+            @Valid @RequestBody AdminItemPresignPutBatchRequestDto request
+    ) {
+        return ApiResult.success(
+                SuccessType.MEDIA_PRESIGN_CREATED,
+                adminItemService.createJournalFilePresignPutBatch(projectId, request)
+        );
+    }
+
     @DeleteMapping("/items/{itemId}")
     @Override
     public ApiResult<?> deleteItem(
@@ -106,7 +119,7 @@ public class AdminItemController implements AdminItemControllerDocs {
             @PathVariable Long itemId
     ) {
         adminItemService.deleteThumbnail(itemId);
-        return ApiResult.success(SuccessType.NO_CONTENT);
+        return ApiResult.success(SuccessType.SUCCESS);
     }
 
     @PostMapping("/items/{itemId}/images")
@@ -135,5 +148,16 @@ public class AdminItemController implements AdminItemControllerDocs {
     ) {
         adminItemService.deleteImage(itemId, imageId);
         return ApiResult.success(SuccessType.SUCCESS);
+    }
+
+    @GetMapping("/items/{itemId}/journal/presign-get")
+    @Override
+    public ApiResult<ProjectItemJournalPresignGetResponseDto> presignJournalDownloadForAdmin(
+            @PathVariable Long itemId
+    ) {
+        return ApiResult.success(
+                SuccessType.MEDIA_PRESIGN_CREATED,
+                adminItemService.createJournalPresignGet(itemId)
+        );
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
@@ -10,6 +10,7 @@ import com.example.cowmjucraft.domain.item.dto.response.AdminItemPresignPutBatch
 import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemDetailResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.AdminProjectItemResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemImageResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemJournalPresignGetResponseDto;
 import com.example.cowmjucraft.global.response.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -62,29 +63,52 @@ public interface AdminItemControllerDocs {
 
     @Operation(
             summary = "프로젝트 물품 생성",
-            description = "프로젝트에 새로운 물품을 생성합니다."
+            description = """
+                    프로젝트에 새로운 물품을 생성합니다.
+                    JOURNAL 아이템 업로드는 2-step입니다.
+                    Step1) /api/admin/projects/{projectId}/journals/presign-put 호출 → uploadUrl로 PUT 업로드
+                    Step2) 생성 요청의 journalFileKey에 Step1의 key 저장
+                    """
     )
     @RequestBody(
             required = true,
             description = "물품 생성 요청",
             content = @Content(
                     schema = @Schema(implementation = AdminProjectItemCreateRequestDto.class),
-                    examples = @ExampleObject(
-                            name = "item-create-request",
-                            value = """
-                                    {
-                                      "name": "명지공방 머그컵",
-                                      "summary": "캠퍼스 감성을 담은 데일리 머그컵",
-                                      "description": "캠퍼스 감성을 담은 머그컵입니다.",
-                                      "price": 12000,
-                                      "saleType": "GROUPBUY",
-                                      "status": "OPEN",
-                                      "thumbnailKey": "uploads/items/1/thumbnail/uuid-thumbnail.png",
-                                      "targetQty": 100,
-                                      "fundedQty": 0
-                                    }
-                                    """
-                    )
+                    examples = {
+                            @ExampleObject(
+                                    name = "item-create-request",
+                                    value = """
+                                            {
+                                              "name": "명지공방 머그컵",
+                                              "summary": "캠퍼스 감성을 담은 데일리 머그컵",
+                                              "description": "캠퍼스 감성을 담은 머그컵입니다.",
+                                              "price": 12000,
+                                              "saleType": "GROUPBUY",
+                                              "itemType": "PHYSICAL",
+                                              "status": "OPEN",
+                                              "thumbnailKey": "uploads/items/1/thumbnail/uuid-thumbnail.png",
+                                              "targetQty": 100,
+                                              "fundedQty": 0
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "journal-item-create-request",
+                                    value = """
+                                            {
+                                              "name": "2026 겨울 저널",
+                                              "summary": "연말 회고 저널",
+                                              "description": "2026 연말 회고용 디지털 저널입니다.",
+                                              "price": 0,
+                                              "saleType": "NORMAL",
+                                              "itemType": "DIGITAL_JOURNAL",
+                                              "status": "OPEN",
+                                              "journalFileKey": "uploads/projects/1/journals/uuid-journal-2026.pdf"
+                                            }
+                                            """
+                            )
+                    }
             )
     )
     @ApiResponses({
@@ -132,29 +156,52 @@ public interface AdminItemControllerDocs {
 
     @Operation(
             summary = "프로젝트 물품 수정",
-            description = "물품 정보를 수정합니다."
+            description = """
+                    물품 정보를 수정합니다.
+                    JOURNAL 아이템 업로드는 2-step입니다.
+                    Step1) /api/admin/projects/{projectId}/journals/presign-put 호출 → uploadUrl로 PUT 업로드
+                    Step2) 수정 요청의 journalFileKey에 Step1의 key 저장
+                    """
     )
     @RequestBody(
             required = true,
             description = "물품 수정 요청",
             content = @Content(
                     schema = @Schema(implementation = AdminProjectItemUpdateRequestDto.class),
-                    examples = @ExampleObject(
-                            name = "item-update-request",
-                            value = """
-                                    {
-                                      "name": "명지공방 머그컵",
-                                      "summary": "캠퍼스 감성을 담은 데일리 머그컵",
-                                      "description": "캠퍼스 감성을 담은 머그컵입니다.",
-                                      "price": 11000,
-                                      "saleType": "NORMAL",
-                                      "status": "OPEN",
-                                      "thumbnailKey": "uploads/items/1/thumbnail/uuid-thumbnail.png",
-                                      "targetQty": 100,
-                                      "fundedQty": 0
-                                    }
-                                    """
-                    )
+                    examples = {
+                            @ExampleObject(
+                                    name = "item-update-request",
+                                    value = """
+                                            {
+                                              "name": "명지공방 머그컵",
+                                              "summary": "캠퍼스 감성을 담은 데일리 머그컵",
+                                              "description": "캠퍼스 감성을 담은 머그컵입니다.",
+                                              "price": 11000,
+                                              "saleType": "NORMAL",
+                                              "itemType": "PHYSICAL",
+                                              "status": "OPEN",
+                                              "thumbnailKey": "uploads/items/1/thumbnail/uuid-thumbnail.png",
+                                              "targetQty": 100,
+                                              "fundedQty": 0
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "journal-item-update-request",
+                                    value = """
+                                            {
+                                              "name": "2026 겨울 저널",
+                                              "summary": "연말 회고 저널",
+                                              "description": "2026 연말 회고용 디지털 저널입니다.",
+                                              "price": 0,
+                                              "saleType": "NORMAL",
+                                              "itemType": "DIGITAL_JOURNAL",
+                                              "status": "OPEN",
+                                              "journalFileKey": "uploads/projects/1/journals/uuid-journal-2026.pdf"
+                                            }
+                                            """
+                            )
+                    }
             )
     )
     @ApiResponses({
@@ -303,12 +350,76 @@ public interface AdminItemControllerDocs {
     );
 
     @Operation(
+            summary = "저널 파일 presign-put 발급",
+            description = """
+                    저널 파일 업로드용 presigned PUT URL을 발급합니다.
+                    Step1) presign-put으로 key, uploadUrl 획득
+                    Step2) uploadUrl로 PUT 업로드
+                    Step3) 아이템 생성/수정 요청의 journalFileKey에 Step1의 key 저장
+                    """
+    )
+    @RequestBody(
+            required = true,
+            description = "presign-put 요청",
+            content = @Content(
+                    schema = @Schema(implementation = AdminItemPresignPutBatchRequestDto.class),
+                    examples = @ExampleObject(
+                            name = "journal-presign-request",
+                            value = """
+                                    {
+                                      "files": [
+                                        { "fileName": "journal-2026-01.pdf", "contentType": "application/pdf" }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "journal-presign-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "Presign URL 발급 완료",
+                                              "data": {
+                                                "items": [
+                                                  {
+                                                    "fileName": "journal-2026-01.pdf",
+                                                    "key": "uploads/projects/1/journals/uuid-journal-2026-01.pdf",
+                                                    "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+                                                    "expiresInSeconds": 300
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<AdminItemPresignPutBatchResponseDto> presignJournalFile(
+            @Parameter(description = "프로젝트 ID", example = "1")
+            Long projectId,
+            @Valid AdminItemPresignPutBatchRequestDto request
+    );
+
+    // ✅ 변경: 204 -> 200
+    @Operation(
             summary = "프로젝트 물품 삭제",
             description = "물품을 삭제합니다."
     )
     @ApiResponses({
             @ApiResponse(
-                    responseCode = "204",
+                    responseCode = "200",
                     description = "성공",
                     content = @Content(
                             schema = @Schema(implementation = ApiResult.class),
@@ -317,7 +428,7 @@ public interface AdminItemControllerDocs {
                                     value = """
                                             {
                                               "resultType": "SUCCESS",
-                                              "httpStatusCode": 204,
+                                              "httpStatusCode": 200,
                                               "message": "요청에 성공하였습니다.",
                                               "data": null
                                             }
@@ -332,13 +443,14 @@ public interface AdminItemControllerDocs {
             Long itemId
     );
 
+    // ✅ 변경: 204 -> 200
     @Operation(
             summary = "물품 썸네일 삭제",
             description = "물품의 대표 이미지(thumbnailKey)를 제거하고 S3에서도 파일을 삭제합니다."
     )
     @ApiResponses({
             @ApiResponse(
-                    responseCode = "204",
+                    responseCode = "200",
                     description = "성공",
                     content = @Content(schema = @Schema(implementation = ApiResult.class))
             ),
@@ -442,13 +554,14 @@ public interface AdminItemControllerDocs {
             @Valid AdminItemImageOrderPatchRequestDto request
     );
 
+    // ✅ 변경: 204 -> 200
     @Operation(
             summary = "물품 이미지 삭제",
             description = "단일 물품 이미지를 삭제합니다."
     )
     @ApiResponses({
             @ApiResponse(
-                    responseCode = "204",
+                    responseCode = "200",
                     description = "성공",
                     content = @Content(
                             schema = @Schema(implementation = ApiResult.class),
@@ -457,7 +570,7 @@ public interface AdminItemControllerDocs {
                                     value = """
                                             {
                                               "resultType": "SUCCESS",
-                                              "httpStatusCode": 204,
+                                              "httpStatusCode": 200,
                                               "message": "요청에 성공하였습니다.",
                                               "data": null
                                             }
@@ -473,5 +586,41 @@ public interface AdminItemControllerDocs {
             Long itemId,
             @Parameter(description = "이미지 ID", example = "1")
             Long imageId
+    );
+
+    @Operation(
+            summary = "저널 다운로드 presign-get 발급 (관리자)",
+            description = """
+                    DIGITAL_JOURNAL 아이템 다운로드용 presigned GET URL을 발급합니다.
+                    downloadUrl은 Content-Disposition=attachment로 내려가며 브라우저 다운로드가 동작합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "admin-journal-presign-get-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "Presign URL 발급 완료",
+                                              "data": {
+                                                "downloadUrl": "https://bucket.s3.amazonaws.com/uploads/projects/1/journals/uuid-journal-2026.pdf?X-Amz-Signature=..."
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<ProjectItemJournalPresignGetResponseDto> presignJournalDownloadForAdmin(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId
     );
 }

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemController.java
@@ -1,6 +1,7 @@
 package com.example.cowmjucraft.domain.item.controller.client;
 
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemDetailResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemJournalPresignGetResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemListResponseDto;
 import com.example.cowmjucraft.domain.item.service.ItemService;
 import com.example.cowmjucraft.global.response.ApiResult;
@@ -9,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,5 +35,13 @@ public class ItemController implements ItemControllerDocs {
             @PathVariable Long itemId
     ) {
         return ApiResult.success(SuccessType.SUCCESS, itemService.getItem(itemId));
+    }
+
+    @PostMapping("/items/{itemId}/journal/presign-get")
+    @Override
+    public ApiResult<ProjectItemJournalPresignGetResponseDto> presignJournalDownload(
+            @PathVariable Long itemId
+    ) {
+        return ApiResult.success(SuccessType.MEDIA_PRESIGN_CREATED, itemService.createJournalPresignGet(itemId));
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/client/ItemControllerDocs.java
@@ -1,6 +1,7 @@
 package com.example.cowmjucraft.domain.item.controller.client;
 
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemDetailResponseDto;
+import com.example.cowmjucraft.domain.item.dto.response.ProjectItemJournalPresignGetResponseDto;
 import com.example.cowmjucraft.domain.item.dto.response.ProjectItemListResponseDto;
 import com.example.cowmjucraft.global.response.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -110,6 +111,42 @@ public interface ItemControllerDocs {
             @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
     })
     ApiResult<ProjectItemDetailResponseDto> getItem(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId
+    );
+
+    @Operation(
+            summary = "저널 다운로드 presign-get 발급",
+            description = """
+                    DIGITAL_JOURNAL 아이템 다운로드용 presigned GET URL을 발급합니다.
+                    downloadUrl은 Content-Disposition=attachment로 내려가며 브라우저 다운로드가 동작합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "journal-presign-get-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "Presign URL 발급 완료",
+                                              "data": {
+                                                "downloadUrl": "https://bucket.s3.amazonaws.com/uploads/projects/1/journals/uuid-journal.pdf?X-Amz-Signature=..."
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+            @ApiResponse(responseCode = "422", description = "요청 값 검증 실패")
+    })
+    ApiResult<ProjectItemJournalPresignGetResponseDto> presignJournalDownload(
             @Parameter(description = "물품 ID", example = "1")
             Long itemId
     );

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
@@ -2,6 +2,7 @@ package com.example.cowmjucraft.domain.item.dto.request;
 
 import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
 import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.example.cowmjucraft.domain.item.entity.ItemType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -35,13 +36,19 @@ public record AdminProjectItemCreateRequestDto(
         @Schema(description = "상태", example = "OPEN")
         ItemStatus status,
 
-        @Schema(description = "대표 이미지 S3 object key", example = "uploads/items/1/thumbnail/uuid-thumbnail.png")
+        @Schema(description = "대표 이미지 S3 object key (PHYSICAL 전용)", example = "uploads/items/1/thumbnail/uuid-thumbnail.png")
         String thumbnailKey,
 
         @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
         Integer targetQty,
 
         @Schema(description = "현재 모금 수량 (미입력 시 0)", example = "0")
-        Integer fundedQty
+        Integer fundedQty,
+
+        @Schema(description = "아이템 타입", example = "PHYSICAL")
+        ItemType itemType,
+
+        @Schema(description = "저널 파일 S3 object key (presign-put 결과 key)", example = "uploads/projects/1/journals/uuid-journal.pdf")
+        String journalFileKey
 ) {
 }

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
@@ -2,6 +2,7 @@ package com.example.cowmjucraft.domain.item.dto.request;
 
 import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
 import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.example.cowmjucraft.domain.item.entity.ItemType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -35,8 +36,7 @@ public record AdminProjectItemUpdateRequestDto(
         @Schema(description = "상태", example = "OPEN")
         ItemStatus status,
 
-        @NotBlank
-        @Schema(description = "대표 이미지 S3 object key", example = "uploads/items/1/thumbnail/uuid-thumbnail.png")
+        @Schema(description = "대표 이미지 S3 object key (PHYSICAL 전용)", example = "uploads/items/1/thumbnail/uuid-thumbnail.png")
         String thumbnailKey,
 
         @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
@@ -44,6 +44,12 @@ public record AdminProjectItemUpdateRequestDto(
 
         @NotNull
         @Schema(description = "현재 모금 수량", example = "0")
-        Integer fundedQty
+        Integer fundedQty,
+
+        @Schema(description = "아이템 타입", example = "PHYSICAL")
+        ItemType itemType,
+
+        @Schema(description = "저널 파일 S3 object key (presign-put 결과 key)", example = "uploads/projects/1/journals/uuid-journal.pdf")
+        String journalFileKey
 ) {
 }

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemDetailResponseDto.java
@@ -2,6 +2,7 @@ package com.example.cowmjucraft.domain.item.dto.response;
 
 import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
 import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.example.cowmjucraft.domain.item.entity.ItemType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -31,6 +32,9 @@ public record AdminProjectItemDetailResponseDto(
         @Schema(description = "판매 유형", example = "GROUPBUY")
         ItemSaleType saleType,
 
+        @Schema(description = "아이템 타입", example = "PHYSICAL")
+        ItemType itemType,
+
         @Schema(description = "상태", example = "OPEN")
         ItemStatus status,
 
@@ -39,6 +43,9 @@ public record AdminProjectItemDetailResponseDto(
 
         @Schema(description = "대표 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png?X-Amz-Signature=...")
         String thumbnailUrl,
+
+        @Schema(description = "저널 파일 S3 object key", example = "uploads/projects/1/journals/uuid-journal.pdf")
+        String journalFileKey,
 
         @Schema(description = "상세 이미지 목록")
         List<ProjectItemImageResponseDto> images,

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/AdminProjectItemResponseDto.java
@@ -2,6 +2,7 @@ package com.example.cowmjucraft.domain.item.dto.response;
 
 import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
 import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.example.cowmjucraft.domain.item.entity.ItemType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -30,6 +31,9 @@ public record AdminProjectItemResponseDto(
         @Schema(description = "판매 유형", example = "GROUPBUY")
         ItemSaleType saleType,
 
+        @Schema(description = "아이템 타입", example = "PHYSICAL")
+        ItemType itemType,
+
         @Schema(description = "상태", example = "OPEN")
         ItemStatus status,
 
@@ -38,6 +42,9 @@ public record AdminProjectItemResponseDto(
 
         @Schema(description = "대표 이미지 URL", example = "https://bucket.s3.amazonaws.com/uploads/items/1/thumbnail/uuid-thumbnail.png?X-Amz-Signature=...")
         String thumbnailUrl,
+
+        @Schema(description = "저널 파일 S3 object key", example = "uploads/projects/1/journals/uuid-journal.pdf")
+        String journalFileKey,
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemDetailResponseDto.java
@@ -2,6 +2,7 @@ package com.example.cowmjucraft.domain.item.dto.response;
 
 import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
 import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.example.cowmjucraft.domain.item.entity.ItemType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -29,6 +30,9 @@ public record ProjectItemDetailResponseDto(
 
         @Schema(description = "판매 유형", example = "GROUPBUY")
         ItemSaleType saleType,
+
+        @Schema(description = "아이템 타입", example = "PHYSICAL")
+        ItemType itemType,
 
         @Schema(description = "상태", example = "OPEN")
         ItemStatus status,

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemJournalPresignGetResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemJournalPresignGetResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.cowmjucraft.domain.item.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "저널 다운로드 presign-get 응답")
+public record ProjectItemJournalPresignGetResponseDto(
+
+        @Schema(description = "저널 다운로드 URL", example = "https://bucket.s3.amazonaws.com/uploads/projects/1/journals/uuid-journal.pdf?X-Amz-Signature=...")
+        String downloadUrl
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemListResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/response/ProjectItemListResponseDto.java
@@ -2,6 +2,7 @@ package com.example.cowmjucraft.domain.item.dto.response;
 
 import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
 import com.example.cowmjucraft.domain.item.entity.ItemStatus;
+import com.example.cowmjucraft.domain.item.entity.ItemType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -22,6 +23,9 @@ public record ProjectItemListResponseDto(
 
         @Schema(description = "판매 유형", example = "NORMAL")
         ItemSaleType saleType,
+
+        @Schema(description = "아이템 타입", example = "PHYSICAL")
+        ItemType itemType,
 
         @Schema(description = "상태", example = "OPEN")
         ItemStatus status,

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ItemType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ItemType.java
@@ -1,0 +1,6 @@
+package com.example.cowmjucraft.domain.item.entity;
+
+public enum ItemType {
+    PHYSICAL,
+    DIGITAL_JOURNAL
+}

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
@@ -53,8 +53,15 @@ public class ProjectItem extends BaseTimeEntity {
     @Column(nullable = false)
     private ItemStatus status;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ItemType itemType;
+
     @Column(length = 255)
     private String thumbnailKey;
+
+    @Column(length = 255)
+    private String journalFileKey;
 
     @Column(name = "target_qty")
     private Integer targetQty;
@@ -70,7 +77,9 @@ public class ProjectItem extends BaseTimeEntity {
             int price,
             ItemSaleType saleType,
             ItemStatus status,
+            ItemType itemType,
             String thumbnailKey,
+            String journalFileKey,
             Integer targetQty,
             int fundedQty
     ) {
@@ -81,7 +90,9 @@ public class ProjectItem extends BaseTimeEntity {
         this.price = price;
         this.saleType = saleType;
         this.status = status;
+        this.itemType = itemType == null ? ItemType.PHYSICAL : itemType;
         this.thumbnailKey = thumbnailKey;
+        this.journalFileKey = journalFileKey;
         this.targetQty = targetQty;
         this.fundedQty = fundedQty;
     }
@@ -93,7 +104,9 @@ public class ProjectItem extends BaseTimeEntity {
             int price,
             ItemSaleType saleType,
             ItemStatus status,
+            ItemType itemType,
             String thumbnailKey,
+            String journalFileKey,
             Integer targetQty,
             int fundedQty
     ) {
@@ -103,7 +116,11 @@ public class ProjectItem extends BaseTimeEntity {
         this.price = price;
         this.saleType = saleType;
         this.status = status;
+        if (itemType != null) {
+            this.itemType = itemType;
+        }
         this.thumbnailKey = thumbnailKey;
+        this.journalFileKey = journalFileKey;
         this.targetQty = targetQty;
         this.fundedQty = fundedQty;
     }

--- a/src/main/java/com/example/cowmjucraft/domain/notice/controller/admin/AdminNoticeController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/notice/controller/admin/AdminNoticeController.java
@@ -59,7 +59,7 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
             @PathVariable Long noticeId
     ) {
         adminNoticeService.delete(noticeId);
-        return ApiResult.success(SuccessType.NO_CONTENT);
+        return ApiResult.success(SuccessType.SUCCESS);
     }
 
     @GetMapping

--- a/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/controller/admin/AdminProjectController.java
@@ -83,7 +83,7 @@ public class AdminProjectController implements AdminProjectControllerDocs {
             @PathVariable Long projectId
     ) {
         adminProjectService.delete(projectId);
-        return ApiResult.success(SuccessType.NO_CONTENT);
+        return ApiResult.success(SuccessType.SUCCESS);
     }
 
     @PatchMapping("/order")

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.cowmjucraft.domain.project.dto.request;
 
+import com.example.cowmjucraft.domain.project.entity.ProjectCategory;
 import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -39,6 +40,9 @@ public record AdminProjectCreateRequestDto(
 
         @NotNull
         @Schema(description = "프로젝트 상태", example = "OPEN")
-        ProjectStatus status
+        ProjectStatus status,
+
+        @Schema(description = "프로젝트 카테고리", example = "GOODS")
+        ProjectCategory category
 ) {
 }

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/request/AdminProjectUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.cowmjucraft.domain.project.dto.request;
 
+import com.example.cowmjucraft.domain.project.entity.ProjectCategory;
 import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -39,6 +40,9 @@ public record AdminProjectUpdateRequestDto(
 
         @NotNull
         @Schema(description = "프로젝트 상태", example = "OPEN")
-        ProjectStatus status
+        ProjectStatus status,
+
+        @Schema(description = "프로젝트 카테고리", example = "GOODS")
+        ProjectCategory category
 ) {
 }

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/AdminProjectResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.cowmjucraft.domain.project.dto.response;
 
+import com.example.cowmjucraft.domain.project.entity.ProjectCategory;
 import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
@@ -35,6 +36,9 @@ public record AdminProjectResponseDto(
 
         @Schema(description = "프로젝트 상태", example = "OPEN")
         ProjectStatus status,
+
+        @Schema(description = "프로젝트 카테고리", example = "GOODS")
+        ProjectCategory category,
 
         @Schema(description = "마감일 (YYYY-MM-DD)", example = "2026-03-15")
         LocalDate deadlineDate,

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.cowmjucraft.domain.project.dto.response;
 
+import com.example.cowmjucraft.domain.project.entity.ProjectCategory;
 import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
@@ -43,6 +44,9 @@ public record ProjectDetailResponseDto(
 
         @Schema(description = "프로젝트 상태", example = "OPEN")
         ProjectStatus status,
+
+        @Schema(description = "프로젝트 카테고리", example = "GOODS")
+        ProjectCategory category,
 
         @Schema(description = "마감일 (YYYY-MM-DD)", example = "2026-03-15")
         LocalDate deadlineDate,

--- a/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectListItemResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/dto/response/ProjectListItemResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.cowmjucraft.domain.project.dto.response;
 
+import com.example.cowmjucraft.domain.project.entity.ProjectCategory;
 import com.example.cowmjucraft.domain.project.entity.ProjectStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
@@ -28,6 +29,9 @@ public record ProjectListItemResponseDto(
 
         @Schema(description = "프로젝트 상태", example = "OPEN")
         ProjectStatus status,
+
+        @Schema(description = "프로젝트 카테고리", example = "GOODS")
+        ProjectCategory category,
 
         @Schema(description = "마감일 (YYYY-MM-DD)", example = "2026-03-15")
         LocalDate deadlineDate,

--- a/src/main/java/com/example/cowmjucraft/domain/project/entity/Project.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/entity/Project.java
@@ -57,6 +57,10 @@ public class Project extends BaseTimeEntity {
     @Column(nullable = false)
     private ProjectStatus status;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProjectCategory category;
+
     @Column(nullable = false)
     private boolean pinned = false;
 
@@ -73,7 +77,8 @@ public class Project extends BaseTimeEntity {
             String thumbnailKey,
             List<String> imageKeys,
             LocalDate deadlineDate,
-            ProjectStatus status
+            ProjectStatus status,
+            ProjectCategory category
     ) {
         this.title = title;
         this.summary = summary;
@@ -82,6 +87,7 @@ public class Project extends BaseTimeEntity {
         replaceImageKeys(imageKeys);
         this.deadlineDate = deadlineDate;
         this.status = status;
+        this.category = category == null ? ProjectCategory.GOODS : category;
     }
 
     public void updateBasic(
@@ -91,7 +97,8 @@ public class Project extends BaseTimeEntity {
             String thumbnailKey,
             List<String> imageKeys,
             LocalDate deadlineDate,
-            ProjectStatus status
+            ProjectStatus status,
+            ProjectCategory category
     ) {
         this.title = title;
         this.summary = summary;
@@ -100,6 +107,9 @@ public class Project extends BaseTimeEntity {
         replaceImageKeys(imageKeys);
         this.deadlineDate = deadlineDate;
         this.status = status;
+        if (category != null) {
+            this.category = category;
+        }
     }
 
     public void applyPinned(boolean pinned, Integer pinnedOrder) {

--- a/src/main/java/com/example/cowmjucraft/domain/project/entity/ProjectCategory.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/entity/ProjectCategory.java
@@ -1,0 +1,6 @@
+package com.example.cowmjucraft.domain.project.entity;
+
+public enum ProjectCategory {
+    GOODS,
+    JOURNAL
+}

--- a/src/main/java/com/example/cowmjucraft/domain/project/service/AdminProjectService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/service/AdminProjectService.java
@@ -8,6 +8,7 @@ import com.example.cowmjucraft.domain.project.dto.response.AdminProjectOrderPatc
 import com.example.cowmjucraft.domain.project.dto.response.AdminProjectPresignPutBatchResponseDto;
 import com.example.cowmjucraft.domain.project.dto.response.AdminProjectResponseDto;
 import com.example.cowmjucraft.domain.project.entity.Project;
+import com.example.cowmjucraft.domain.project.entity.ProjectCategory;
 import com.example.cowmjucraft.domain.project.repository.ProjectRepository;
 import com.example.cowmjucraft.global.cloud.S3PresignFacade;
 import java.util.ArrayList;
@@ -48,7 +49,8 @@ public class AdminProjectService {
                 request.thumbnailKey(),
                 normalizeImageKeys(request.imageKeys()),
                 request.deadlineDate(),
-                request.status()
+                request.status(),
+                resolveCategory(request.category())
         );
         Project saved = projectRepository.save(project);
         Map<String, String> urls = presignGetForProject(saved);
@@ -65,7 +67,8 @@ public class AdminProjectService {
                 request.thumbnailKey(),
                 normalizeImageKeys(request.imageKeys()),
                 request.deadlineDate(),
-                request.status()
+                request.status(),
+                request.category()
         );
         Map<String, String> urls = presignGetForProject(project);
         return toAdminResponse(project, urls);
@@ -291,6 +294,10 @@ public class AdminProjectService {
         return new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, message);
     }
 
+    private ProjectCategory resolveCategory(ProjectCategory category) {
+        return category == null ? ProjectCategory.GOODS : category;
+    }
+
     private AdminProjectResponseDto toAdminResponse(Project project, Map<String, String> urls) {
         return new AdminProjectResponseDto(
                 project.getId(),
@@ -302,6 +309,7 @@ public class AdminProjectService {
                 project.getImageKeys(),
                 buildUrlsForKeys(project.getImageKeys(), urls),
                 project.getStatus(),
+                project.getCategory(),
                 project.getDeadlineDate(),
                 project.isPinned(),
                 project.getPinnedOrder(),

--- a/src/main/java/com/example/cowmjucraft/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/project/service/ProjectService.java
@@ -45,6 +45,7 @@ public class ProjectService {
                         project.getThumbnailKey(),
                         resolveUrl(urls, project.getThumbnailKey()),
                         project.getStatus(),
+                        project.getCategory(),
                         project.getDeadlineDate(),
                         calculateDDay(project.getDeadlineDate()),
                         project.isPinned()
@@ -72,6 +73,7 @@ public class ProjectService {
                 project.getImageKeys(),
                 buildUrlsForKeys(project.getImageKeys(), urls),
                 project.getStatus(),
+                project.getCategory(),
                 project.getDeadlineDate(),
                 calculateDDay(project.getDeadlineDate()),
                 project.getCreatedAt(),

--- a/src/main/java/com/example/cowmjucraft/global/cloud/S3PresignFacade.java
+++ b/src/main/java/com/example/cowmjucraft/global/cloud/S3PresignFacade.java
@@ -65,6 +65,18 @@ public class S3PresignFacade {
         return urls;
     }
 
+    public String presignGet(
+            String key,
+            String downloadFileName,
+            String contentType,
+            boolean asAttachment
+    ) {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("요청 형식이 올바르지 않습니다. (key: 공백일 수 없습니다.)");
+        }
+        return s3PresignService.presignGet(key.trim(), downloadFileName, contentType, asAttachment).downloadUrl();
+    }
+
     public void deleteByKeys(List<String> keys) {
         if (keys == null || keys.isEmpty()) {
             throw new IllegalArgumentException("요청 형식이 올바르지 않습니다. (keys: 비어 있을 수 없습니다.)");

--- a/src/main/java/com/example/cowmjucraft/global/response/type/SuccessType.java
+++ b/src/main/java/com/example/cowmjucraft/global/response/type/SuccessType.java
@@ -9,7 +9,6 @@ public enum SuccessType {
 
     SUCCESS(200, "요청에 성공하였습니다."),
     CREATED(201, "성공적으로 생성하였습니다."),
-    NO_CONTENT(204, "요청에 성공하였습니다."),
 
     MEDIA_PRESIGN_CREATED(200, "Presign URL 발급 완료"),
     MEDIA_DELETED(200, "미디어 삭제 완료");


### PR DESCRIPTION
# 요약

DIGITAL_JOURNAL 타입 아이템을 위한 업로드/다운로드 플로우를 추가했습니다.  
S3 presigned URL 기반으로 저널 파일을 업로드하고, 관리자/사용자에서 다운로드할 수 있도록 구현했습니다.

---

# 작업 내용

- [x] DIGITAL_JOURNAL 아이템 타입 추가 및 생성/수정 시 검증 로직 구현
  - JOURNAL 프로젝트에서는 DIGITAL_JOURNAL만 생성 가능하도록 제한
  - 저널 아이템은 price=0, saleType=NORMAL, journalFileKey 필수 검증

- [x] 저널 파일 업로드용 presign-put API 추가
  - `/api/admin/projects/{projectId}/journals/presign-put`
  - 프로젝트 단위 prefix(`uploads/projects/{id}/journals`) 적용

- [x] 저널 파일 다운로드용 presign-get API 추가
  - 관리자: `/api/admin/items/{itemId}/journal/presign-get`
  - Content-Disposition=attachment 적용
  - UTF-8 파일명 안전 처리(filename / filename*)

- [x] 관리자 API 기준 Swagger 문서 정비
  - JOURNAL 아이템 2-step 업로드 플로우 명시
  - 삭제 API 응답 코드 200으로 통일

- [x] S3PresignService 확장
  - 다운로드 시 responseContentDisposition / responseContentType 지원

---

# 타 직군 전달 사항

- 관리자 화면에서 itemType === DIGITAL_JOURNAL 인 경우
  - 아이템 상세/목록에 “다운로드” 버튼 노출
  - 클릭 시 관리자 presign-get API 호출 후 downloadUrl로 이동
- 저널 업로드는 2-step(presign-put → PUT 업로드 → key 저장) 구조입니다.