### PR TITLE
feat: 저널 파일 삭제 기능 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemController.java
@@ -110,7 +110,7 @@ public class AdminItemController implements AdminItemControllerDocs {
             @PathVariable Long itemId
     ) {
         adminItemService.delete(itemId);
-        return ApiResult.success(SuccessType.SUCCESS);
+        return ApiResult.success(SuccessType.MEDIA_DELETED);
     }
 
     @DeleteMapping("/items/{itemId}/thumbnail")
@@ -119,7 +119,16 @@ public class AdminItemController implements AdminItemControllerDocs {
             @PathVariable Long itemId
     ) {
         adminItemService.deleteThumbnail(itemId);
-        return ApiResult.success(SuccessType.SUCCESS);
+        return ApiResult.success(SuccessType.MEDIA_DELETED);
+    }
+
+    @DeleteMapping("/items/{itemId}/journal")
+    @Override
+    public ApiResult<?> deleteJournalFile(
+            @PathVariable Long itemId
+    ) {
+        adminItemService.deleteJournalFile(itemId);
+        return ApiResult.success(SuccessType.MEDIA_DELETED);
     }
 
     @PostMapping("/items/{itemId}/images")
@@ -147,7 +156,7 @@ public class AdminItemController implements AdminItemControllerDocs {
             @PathVariable Long imageId
     ) {
         adminItemService.deleteImage(itemId, imageId);
-        return ApiResult.success(SuccessType.SUCCESS);
+        return ApiResult.success(SuccessType.MEDIA_DELETED);
     }
 
     @GetMapping("/items/{itemId}/journal/presign-get")

--- a/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/controller/admin/AdminItemControllerDocs.java
@@ -412,7 +412,6 @@ public interface AdminItemControllerDocs {
             @Valid AdminItemPresignPutBatchRequestDto request
     );
 
-    // ✅ 변경: 204 -> 200
     @Operation(
             summary = "프로젝트 물품 삭제",
             description = "물품을 삭제합니다."
@@ -429,7 +428,7 @@ public interface AdminItemControllerDocs {
                                             {
                                               "resultType": "SUCCESS",
                                               "httpStatusCode": 200,
-                                              "message": "요청에 성공하였습니다.",
+                                              "message": "미디어 삭제 완료",
                                               "data": null
                                             }
                                             """
@@ -443,7 +442,6 @@ public interface AdminItemControllerDocs {
             Long itemId
     );
 
-    // ✅ 변경: 204 -> 200
     @Operation(
             summary = "물품 썸네일 삭제",
             description = "물품의 대표 이미지(thumbnailKey)를 제거하고 S3에서도 파일을 삭제합니다."
@@ -452,11 +450,59 @@ public interface AdminItemControllerDocs {
             @ApiResponse(
                     responseCode = "200",
                     description = "성공",
-                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "item-thumbnail-delete-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "미디어 삭제 완료",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
             ),
             @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음")
     })
     ApiResult<?> deleteThumbnail(
+            @Parameter(description = "물품 ID", example = "1")
+            Long itemId
+    );
+
+    @Operation(
+            summary = "저널 파일 삭제 (관리자)",
+            description = """
+                    DIGITAL_JOURNAL 아이템의 journalFileKey에 해당하는 S3 파일을 삭제하고,
+                    DB의 journalFileKey를 null로 clear 합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResult.class),
+                            examples = @ExampleObject(
+                                    name = "item-journal-delete-response",
+                                    value = """
+                                            {
+                                              "resultType": "SUCCESS",
+                                              "httpStatusCode": 200,
+                                              "message": "미디어 삭제 완료",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스를 찾을 수 없음"),
+            @ApiResponse(responseCode = "422", description = "itemType != DIGITAL_JOURNAL 또는 journalFileKey 없음"),
+            @ApiResponse(responseCode = "500", description = "S3 삭제 실패(내부 오류)")
+    })
+    ApiResult<?> deleteJournalFile(
             @Parameter(description = "물품 ID", example = "1")
             Long itemId
     );
@@ -554,7 +600,6 @@ public interface AdminItemControllerDocs {
             @Valid AdminItemImageOrderPatchRequestDto request
     );
 
-    // ✅ 변경: 204 -> 200
     @Operation(
             summary = "물품 이미지 삭제",
             description = "단일 물품 이미지를 삭제합니다."
@@ -571,7 +616,7 @@ public interface AdminItemControllerDocs {
                                             {
                                               "resultType": "SUCCESS",
                                               "httpStatusCode": 200,
-                                              "message": "요청에 성공하였습니다.",
+                                              "message": "미디어 삭제 완료",
                                               "data": null
                                             }
                                             """

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
@@ -128,4 +128,8 @@ public class ProjectItem extends BaseTimeEntity {
     public void clearThumbnail() {
         this.thumbnailKey = null;
     }
+
+    public void clearJournalFileKey() {
+        this.journalFileKey = null;
+    }
 }


### PR DESCRIPTION
# 요약

관리자 전용 디지털 저널 파일 삭제 API를 추가하였습니다.  
DIGITAL_JOURNAL 아이템에 연결된 저널 파일을 S3와 DB에서 함께 삭제할 수 있습니다.

# 작업 내용

- [x] 관리자 저널 파일 삭제 API 추가  
  - `DELETE /api/admin/items/{itemId}/journal`
  - itemType이 DIGITAL_JOURNAL인지 검증
  - journalFileKey 존재 여부 검증
  - S3 파일 삭제 후 DB의 journalFileKey를 null로 clear

- [x] Swagger 문서 보강  
  - 저널 파일 삭제 API 설명 및 응답 예시 추가
  - 실패 케이스(타입 불일치, key 없음, S3 삭제 실패) 명시

# 기타 (논의하고 싶은 부분)

- 현재는 S3 삭제 실패 시 전체 트랜잭션을 실패 처리하도록 구현됨  
  (운영 단계에서 soft-delete 또는 재시도 정책 도입 여부 논의 가능)

# 타 직군 전달 사항

- 관리자 화면에서 DIGITAL_JOURNAL 아이템에 대해  
  “저널 파일 삭제” 버튼을 추가하여 해당 API 호출하면 됩니다.
- 삭제 후에는 journalFileKey가 null로 내려오므로 UI 상태 갱신 필요
