### PR TITLE
feat: 지원서 양식 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/recruit/controller/client/ApplicationController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/controller/client/ApplicationController.java
@@ -4,10 +4,7 @@ import com.example.cowmjucraft.domain.recruit.dto.client.request.ApplicationCrea
 import com.example.cowmjucraft.domain.recruit.dto.client.request.ApplicationReadRequest;
 import com.example.cowmjucraft.domain.recruit.dto.client.request.ApplicationUpdateRequest;
 import com.example.cowmjucraft.domain.recruit.dto.client.request.ResultReadRequest;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ApplicationCreateResponse;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ApplicationReadResponse;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ApplicationUpdateResponse;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ResultReadResponse;
+import com.example.cowmjucraft.domain.recruit.dto.client.response.*;
 import com.example.cowmjucraft.domain.recruit.service.client.ApplicationService;
 import com.example.cowmjucraft.global.cloud.S3PresignFacade;
 import com.example.cowmjucraft.global.response.ApiResult;
@@ -76,6 +73,15 @@ public class ApplicationController implements ApplicationControllerDocs {
         return ApiResult.success(
                 SuccessType.SUCCESS,
                 applicationService.createAnswerFilePresignPut(request)
+        );
+    }
+
+    @Override
+    @GetMapping("/application/form")
+    public ApiResult<ApplicationFormInfoResponse> getOpenForm() {
+        return ApiResult.success(
+                SuccessType.SUCCESS,
+                applicationService.getOpenFormInfo()
         );
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/controller/client/ApplicationControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/controller/client/ApplicationControllerDocs.java
@@ -4,10 +4,7 @@ import com.example.cowmjucraft.domain.recruit.dto.client.request.ApplicationCrea
 import com.example.cowmjucraft.domain.recruit.dto.client.request.ApplicationReadRequest;
 import com.example.cowmjucraft.domain.recruit.dto.client.request.ApplicationUpdateRequest;
 import com.example.cowmjucraft.domain.recruit.dto.client.request.ResultReadRequest;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ApplicationCreateResponse;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ApplicationReadResponse;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ApplicationUpdateResponse;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ResultReadResponse;
+import com.example.cowmjucraft.domain.recruit.dto.client.response.*;
 import com.example.cowmjucraft.global.cloud.S3PresignFacade;
 import com.example.cowmjucraft.global.response.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -143,4 +140,21 @@ public interface ApplicationControllerDocs {
             @Parameter(description = "지원 결과 조회 요청")
             ResultReadRequest request
     );
+
+    @Operation(
+            summary = "지원서 양식(질문 및 공지) 조회",
+            description = """
+                현재 열려있는 모집 폼(Form)의 공지사항과 질문 목록을 조회합니다.
+                지원하기 전 화면을 그릴 때 사용합니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "현재 모집 중인 폼이 없음")
+    })
+    ApiResult<ApplicationFormInfoResponse> getOpenForm();
 }

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/response/ApplicationFormInfoResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/response/ApplicationFormInfoResponse.java
@@ -1,0 +1,68 @@
+package com.example.cowmjucraft.domain.recruit.dto.client.response;
+
+import com.example.cowmjucraft.domain.recruit.entity.Form;
+import com.example.cowmjucraft.domain.recruit.entity.FormNotice;
+import com.example.cowmjucraft.domain.recruit.entity.FormQuestion;
+
+import java.util.List;
+
+public record ApplicationFormInfoResponse(
+        Long formId,
+        String title,
+        List<NoticeDto> notices,
+        List<QuestionDto> questions
+) {
+
+    public static ApplicationFormInfoResponse from(Form form, List<FormNotice> notices, List<FormQuestion> questions) {
+        return new ApplicationFormInfoResponse(
+                form.getId(),
+                form.getTitle(),
+                notices.stream().map(NoticeDto::from).toList(),
+                questions.stream().map(QuestionDto::from).toList()
+        );
+    }
+
+    public record NoticeDto(
+            Long noticeId,
+            String sectionType,
+            String departmentType,
+            String title,
+            String content
+    ) {
+        public static NoticeDto from(FormNotice notice) {
+            return new NoticeDto(
+                    notice.getId(),
+                    notice.getSectionType().name(),
+                    notice.getDepartmentType() != null ? notice.getDepartmentType().name() : null,
+                    notice.getTitle(),
+                    notice.getContent()
+            );
+        }
+    }
+
+    public record QuestionDto(
+            Long formQuestionId,
+            int questionOrder,
+            String content,
+            String description,
+            String answerType,
+            boolean required,
+            String sectionType,
+            String departmentType,
+            String selectOptions
+    ) {
+        public static QuestionDto from(FormQuestion fq) {
+            return new QuestionDto(
+                    fq.getId(),
+                    fq.getQuestionOrder(),
+                    fq.getQuestion().getLabel(),
+                    fq.getQuestion().getDescription(),
+                    fq.getAnswerType().name(),
+                    fq.isRequired(),
+                    fq.getSectionType().name(),
+                    fq.getDepartmentType() != null ? fq.getDepartmentType().name() : null,
+                    fq.getSelectOptions()
+            );
+        }
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
@@ -4,10 +4,7 @@ import com.example.cowmjucraft.domain.recruit.dto.client.request.ApplicationCrea
 import com.example.cowmjucraft.domain.recruit.dto.client.request.ApplicationReadRequest;
 import com.example.cowmjucraft.domain.recruit.dto.client.request.ApplicationUpdateRequest;
 import com.example.cowmjucraft.domain.recruit.dto.client.request.ResultReadRequest;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ApplicationCreateResponse;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ApplicationReadResponse;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ApplicationUpdateResponse;
-import com.example.cowmjucraft.domain.recruit.dto.client.response.ResultReadResponse;
+import com.example.cowmjucraft.domain.recruit.dto.client.response.*;
 import com.example.cowmjucraft.domain.recruit.entity.*;
 import com.example.cowmjucraft.domain.recruit.exception.RecruitException;
 import com.example.cowmjucraft.domain.recruit.repository.*;
@@ -386,6 +383,21 @@ public class ApplicationService {
         }
 
         return new ResultReadResponse(application.getResultStatus());
+    }
+
+    @Transactional(readOnly = true)
+    public ApplicationFormInfoResponse getOpenFormInfo() {
+        Form form = formRepository.findFirstByOpenTrue();
+
+        if (form == null) {
+            throw new RecruitException(ErrorType.FORM_NOT_FOUND);
+        }
+
+        List<FormNotice> notices = formNoticeRepository.findAllByForm(form);
+
+        List<FormQuestion> questions = formQuestionRepository.findAllByFormOrderByQuestionOrderAsc(form);
+
+        return ApplicationFormInfoResponse.from(form, notices, questions);
     }
 
     public S3PresignFacade.PresignPutBatchResult createAnswerFilePresignPut(List<S3PresignFacade.PresignPutFile> files) {


### PR DESCRIPTION
# 요약

지원자가 양식(form)의 질문들과 안내문 조회를 할 수 있는 API를 구현했습니다.

# 작업 내용

- 지원자용 지원서 양식 조회 응답 DTO(ApplicationFormInfoResponse) 신규 생성 
- 지원자용 서비스(ApplicationService)에서 폼의 질문과 공지 조회 기 구현

# 타 직군 전달 사항

GET /api/application/form


