### PR TITLE
feat: 관리자 폼 단일 조회 시 질문, 공지 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/FormDetailAdminResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/FormDetailAdminResponse.java
@@ -1,8 +1,55 @@
 package com.example.cowmjucraft.domain.recruit.dto.admin.response;
 
+import com.example.cowmjucraft.domain.recruit.entity.*;
+import java.util.List;
+
 public record FormDetailAdminResponse(
         Long formId,
         String title,
-        boolean open
+        boolean open,
+        List<NoticeResponse> notices,
+        List<QuestionResponse> questions
 ) {
+    // 내부 record로 간단하게 정의
+    public record NoticeResponse(
+            Long noticeId,
+            String sectionType,
+            String departmentType,
+            String title,
+            String content
+    ) {
+        public static NoticeResponse from(FormNotice notice) {
+            return new NoticeResponse(
+                    notice.getId(),
+                    notice.getSectionType().name(),
+                    notice.getDepartmentType() != null ? notice.getDepartmentType().name() : null,
+                    notice.getTitle(),
+                    notice.getContent()
+            );
+        }
+    }
+
+    public record QuestionResponse(
+            Long formQuestionId,
+            int questionOrder,
+            String content,
+            String answerType,
+            boolean required,
+            String sectionType,
+            String departmentType,
+            String selectOptions
+    ) {
+        public static QuestionResponse from(FormQuestion fq) {
+            return new QuestionResponse(
+                    fq.getId(),
+                    fq.getQuestionOrder(),
+                    fq.getQuestion().getLabel(),
+                    fq.getAnswerType().name(),
+                    fq.isRequired(),
+                    fq.getSectionType().name(),
+                    fq.getDepartmentType() != null ? fq.getDepartmentType().name() : null,
+                    fq.getSelectOptions()
+            );
+        }
+    }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/admin/FormAdminService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/admin/FormAdminService.java
@@ -117,14 +117,19 @@ public class FormAdminService {
 
     @Transactional(readOnly = true)
     public FormDetailAdminResponse getForm(Long formId) {
-
         Form form = formRepository.findById(formId)
                 .orElseThrow(() -> new RecruitException(ErrorType.FORM_NOT_FOUND));
+
+        List<FormNotice> notices = formNoticeRepository.findAllByForm(form);
+
+        List<FormQuestion> questions = formQuestionRepository.findAllByFormOrderByQuestionOrderAsc(form);
 
         return new FormDetailAdminResponse(
                 form.getId(),
                 form.getTitle(),
-                form.isOpen()
+                form.isOpen(),
+                notices.stream().map(FormDetailAdminResponse.NoticeResponse::from).toList(),
+                questions.stream().map(FormDetailAdminResponse.QuestionResponse::from).toList()
         );
     }
 


### PR DESCRIPTION
# 요약

관리자가 기존의 Form 단건 조회에서 Form의 질문들과 안내문 또한 조회할 수 있도록 확장하였습니다.

# 작업 내용

- FormDetailAdminResponse에 questions와 notices 리스트 필드 추가
- FormAdminService에서 폼 상세 조회 시, 질문과 공지 함께 조회하도록 매핑 처리