### PR TITLE
fix: 아이템 생성/수정 시 썸네일 키 정규화 로직 적용

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
@@ -60,7 +60,7 @@ public class AdminItemService {
                 request.saleType(),
                 request.status(),
                 normalized.itemType(),
-                request.thumbnailKey(),
+                normalized.thumbnailKey(),
                 normalized.journalFileKey(),
                 normalized.targetQty(),
                 normalized.fundedQty()
@@ -84,7 +84,7 @@ public class AdminItemService {
                 request.saleType(),
                 request.status(),
                 normalized.itemType(),
-                request.thumbnailKey(),
+                normalized.thumbnailKey(),
                 normalized.journalFileKey(),
                 normalized.targetQty(),
                 normalized.fundedQty()
@@ -451,7 +451,8 @@ public class AdminItemService {
                         "journalFileKey is required for DIGITAL_JOURNAL"
                 );
             }
-            return new NormalizedItemRequest(itemType, null, 0, normalizedJournalKey);
+            String normalizedThumbnailKey = toNonBlankString(thumbnailKey);
+            return new NormalizedItemRequest(itemType, null, 0, normalizedJournalKey, normalizedThumbnailKey);
         }
 
         String normalizedThumbnailKey = toNonBlankString(thumbnailKey);
@@ -486,7 +487,7 @@ public class AdminItemService {
             normalizedTargetQty = null;
         }
 
-        return new NormalizedItemRequest(itemType, normalizedTargetQty, normalizedFundedQty, null);
+        return new NormalizedItemRequest(itemType, normalizedTargetQty, normalizedFundedQty, null, normalizedThumbnailKey);
     }
 
     private ItemType resolveItemType(Project project, ItemType requested, ItemType fallback) {
@@ -696,7 +697,8 @@ public class AdminItemService {
             ItemType itemType,
             Integer targetQty,
             int fundedQty,
-            String journalFileKey
+            String journalFileKey,
+            String thumbnailKey
     ) {
     }
 


### PR DESCRIPTION
# 요약
아이템 생성/수정 시 썸네일 키가 정규화되지 않아 응답 URL이 내려오지 않던 문제를 수정했습니다.  
DIGITAL_JOURNAL / PHYSICAL 공통으로 `thumbnailKey`를 normalize 결과 기준으로 저장하도록 개선했습니다.

# 작업 내용
- 아이템 생성(create) 로직에서 `request.thumbnailKey` 대신  
  `normalize()` 결과의 `thumbnailKey`를 사용하도록 수정
- 아이템 수정(update) 로직에서도 동일하게 normalize 결과를 기준으로 저장하도록 수정
- `NormalizedItemRequest`에 `thumbnailKey`를 포함시켜  
  검증/정규화 책임을 normalize 단계로 일원화

# 기타 (논의하고 싶은 부분)
- DIGITAL_JOURNAL의 썸네일을 **선택값(optional)** 으로 허용한 상태이며  
  추후 필수 여부가 바뀌면 normalize 단에서만 조정하면 됩니다.
- presign-put → update 흐름을 전제로 한 구조라 프론트 연동과 잘 맞습니다.


