### PR TITLE
fix: 디지털 저널 상품 설명 필수 검증 제거

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
@@ -20,7 +20,6 @@ public record AdminProjectItemCreateRequestDto(
         @Schema(description = "물품 한줄 설명", example = "캠퍼스 감성을 담은 데일리 머그컵")
         String summary,
 
-        @NotBlank
         @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
         String description,
 

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
@@ -20,7 +20,6 @@ public record AdminProjectItemUpdateRequestDto(
         @Schema(description = "물품 한줄 설명", example = "캠퍼스 감성을 담은 데일리 머그컵")
         String summary,
 
-        @NotBlank
         @Schema(description = "물품 설명", example = "캠퍼스 감성을 담은 머그컵입니다.")
         String description,
 

--- a/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
@@ -384,6 +384,7 @@ public class AdminItemService {
 
     private NormalizedItemRequest normalizeCreate(Project project, AdminProjectItemCreateRequestDto request) {
         ItemType itemType = resolveItemType(project, request.itemType(), null);
+        validateDescription(itemType, request.description());
         return normalize(
                 itemType,
                 request.price(),
@@ -401,6 +402,7 @@ public class AdminItemService {
             AdminProjectItemUpdateRequestDto request
     ) {
         ItemType itemType = resolveItemType(project, request.itemType(), item.getItemType());
+        validateDescription(itemType, request.description());
         return normalize(
                 itemType,
                 request.price(),
@@ -488,6 +490,15 @@ public class AdminItemService {
         }
 
         return new NormalizedItemRequest(itemType, normalizedTargetQty, normalizedFundedQty, null, normalizedThumbnailKey);
+    }
+
+    private void validateDescription(ItemType itemType, String description) {
+        if (itemType != ItemType.DIGITAL_JOURNAL && toNonBlankString(description) == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNPROCESSABLE_ENTITY,
+                    "description is required for PHYSICAL"
+            );
+        }
     }
 
     private ItemType resolveItemType(Project project, ItemType requested, ItemType fallback) {


### PR DESCRIPTION
## 요약

디지털 저널 상품에서 설명(description)이 없어도 저장 가능하도록 검증 로직을 수정했습니다.

---

## 작업 내용
	•	디지털 저널(DIGITAL_JOURNAL) 타입일 경우 description 필수 검증 제거
	•	기존 일반 상품(PHYSICAL) 검증 로직에는 영향 없도록 분기 처리

