### PR TITLE
feat: 아이템 재고 모델 확정 및 결제 확정(PAID) 처리 흐름 구현

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
@@ -69,6 +69,39 @@ public class ProjectItem extends BaseTimeEntity {
     @Column(name = "funded_qty", nullable = false)
     private int fundedQty;
 
+    @Column(name = "stock_qty")
+    private Integer stockQty;
+
+    public ProjectItem(
+            Project project,
+            String name,
+            String summary,
+            String description,
+            int price,
+            ItemSaleType saleType,
+            ItemStatus status,
+            ItemType itemType,
+            String thumbnailKey,
+            String journalFileKey,
+            Integer targetQty,
+            int fundedQty,
+            Integer stockQty
+    ) {
+        this.project = project;
+        this.name = name;
+        this.summary = summary;
+        this.description = description;
+        this.price = price;
+        this.saleType = saleType;
+        this.status = status;
+        this.itemType = itemType == null ? ItemType.PHYSICAL : itemType;
+        this.thumbnailKey = thumbnailKey;
+        this.journalFileKey = journalFileKey;
+        this.targetQty = targetQty;
+        this.fundedQty = fundedQty;
+        this.stockQty = stockQty;
+    }
+
     public ProjectItem(
             Project project,
             String name,
@@ -83,18 +116,51 @@ public class ProjectItem extends BaseTimeEntity {
             Integer targetQty,
             int fundedQty
     ) {
-        this.project = project;
+        this(
+                project,
+                name,
+                summary,
+                description,
+                price,
+                saleType,
+                status,
+                itemType,
+                thumbnailKey,
+                journalFileKey,
+                targetQty,
+                fundedQty,
+                null
+        );
+    }
+
+    private void update(
+            String name,
+            String summary,
+            String description,
+            int price,
+            ItemSaleType saleType,
+            ItemStatus status,
+            ItemType itemType,
+            String thumbnailKey,
+            String journalFileKey,
+            Integer targetQty,
+            int fundedQty,
+            Integer stockQty
+    ) {
         this.name = name;
         this.summary = summary;
         this.description = description;
         this.price = price;
         this.saleType = saleType;
         this.status = status;
-        this.itemType = itemType == null ? ItemType.PHYSICAL : itemType;
+        if (itemType != null) {
+            this.itemType = itemType;
+        }
         this.thumbnailKey = thumbnailKey;
         this.journalFileKey = journalFileKey;
         this.targetQty = targetQty;
         this.fundedQty = fundedQty;
+        this.stockQty = stockQty;
     }
 
     public void update(
@@ -110,19 +176,24 @@ public class ProjectItem extends BaseTimeEntity {
             Integer targetQty,
             int fundedQty
     ) {
-        this.name = name;
-        this.summary = summary;
-        this.description = description;
-        this.price = price;
-        this.saleType = saleType;
-        this.status = status;
-        if (itemType != null) {
-            this.itemType = itemType;
-        }
-        this.thumbnailKey = thumbnailKey;
-        this.journalFileKey = journalFileKey;
-        this.targetQty = targetQty;
-        this.fundedQty = fundedQty;
+        update(
+                name,
+                summary,
+                description,
+                price,
+                saleType,
+                status,
+                itemType,
+                thumbnailKey,
+                journalFileKey,
+                targetQty,
+                fundedQty,
+                this.stockQty
+        );
+    }
+
+    public void updateStockQty(Integer stockQty) {
+        this.stockQty = stockQty;
     }
 
     public void clearThumbnail() {

--- a/src/main/java/com/example/cowmjucraft/domain/item/repository/ProjectItemRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/repository/ProjectItemRepository.java
@@ -2,9 +2,18 @@ package com.example.cowmjucraft.domain.item.repository;
 
 import com.example.cowmjucraft.domain.item.entity.ProjectItem;
 import java.util.List;
+import java.util.Optional;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProjectItemRepository extends JpaRepository<ProjectItem, Long> {
 
     List<ProjectItem> findByProjectIdOrderByCreatedAtDescIdDesc(Long projectId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select pi from ProjectItem pi where pi.id = :id")
+    Optional<ProjectItem> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/com/example/cowmjucraft/domain/order/entity/Order.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/entity/Order.java
@@ -1,0 +1,48 @@
+package com.example.cowmjucraft.domain.order.entity;
+
+import com.example.cowmjucraft.domain.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "orders")
+public class Order extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    @Column(name = "stock_deducted_at")
+    private LocalDateTime stockDeductedAt;
+
+    public void updateStatus(OrderStatus status) {
+        this.status = status;
+    }
+
+    public void updatePaidAt(LocalDateTime paidAt) {
+        this.paidAt = paidAt;
+    }
+
+    public void updateStockDeductedAt(LocalDateTime stockDeductedAt) {
+        this.stockDeductedAt = stockDeductedAt;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/entity/OrderItem.java
@@ -1,0 +1,43 @@
+package com.example.cowmjucraft.domain.order.entity;
+
+import com.example.cowmjucraft.domain.item.entity.ProjectItem;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "order_items")
+public class OrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_item_id", nullable = false)
+    private ProjectItem projectItem;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(name = "unit_price", nullable = false)
+    private int unitPrice;
+
+    @Column(name = "line_amount", nullable = false)
+    private int lineAmount;
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/entity/OrderStatus.java
@@ -1,0 +1,7 @@
+package com.example.cowmjucraft.domain.order.entity;
+
+public enum OrderStatus {
+    PENDING_DEPOSIT,
+    PAID,
+    CANCELED
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/repository/OrderItemRepository.java
@@ -1,0 +1,10 @@
+package com.example.cowmjucraft.domain.order.repository;
+
+import com.example.cowmjucraft.domain.order.entity.OrderItem;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+    List<OrderItem> findAllByOrderIdOrderByProjectItemIdAsc(Long orderId);
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/repository/OrderRepository.java
@@ -1,0 +1,16 @@
+package com.example.cowmjucraft.domain.order.repository;
+
+import com.example.cowmjucraft.domain.order.entity.Order;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select o from Order o where o.id = :orderId")
+    Optional<Order> findByIdForUpdate(@Param("orderId") Long orderId);
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/AdminOrderPaymentService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/AdminOrderPaymentService.java
@@ -1,0 +1,97 @@
+package com.example.cowmjucraft.domain.order.service;
+
+import com.example.cowmjucraft.domain.item.entity.ItemSaleType;
+import com.example.cowmjucraft.domain.item.entity.ProjectItem;
+import com.example.cowmjucraft.domain.item.repository.ProjectItemRepository;
+import com.example.cowmjucraft.domain.order.entity.Order;
+import com.example.cowmjucraft.domain.order.entity.OrderItem;
+import com.example.cowmjucraft.domain.order.entity.OrderStatus;
+import com.example.cowmjucraft.domain.order.repository.OrderItemRepository;
+import com.example.cowmjucraft.domain.order.repository.OrderRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class AdminOrderPaymentService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final ProjectItemRepository projectItemRepository;
+
+    @Transactional
+    public void confirmPaid(Long orderId) {
+        Order order = orderRepository.findByIdForUpdate(orderId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "주문을 찾을 수 없습니다. (orderId=" + orderId + ")"
+                ));
+
+        if (order.getStatus() != OrderStatus.PENDING_DEPOSIT) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "입금 대기 상태의 주문만 결제 확정할 수 있습니다. (orderId=" + orderId + ")"
+            );
+        }
+
+        if (order.getStockDeductedAt() != null) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "이미 재고 차감이 완료된 주문입니다. 중복 결제 확정을 진행할 수 없습니다. (orderId=" + orderId + ")"
+            );
+        }
+
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrderIdOrderByProjectItemIdAsc(orderId);
+        if (orderItems.isEmpty()) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "주문 항목이 없어 결제 확정을 진행할 수 없습니다. (orderId=" + orderId + ")"
+            );
+        }
+
+        for (OrderItem orderItem : orderItems) {
+            ProjectItem projectItem = projectItemRepository.findByIdForUpdate(orderItem.getProjectItem().getId())
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.NOT_FOUND,
+                            "주문 항목의 상품을 찾을 수 없습니다. (projectItemId="
+                                    + orderItem.getProjectItem().getId() + ")"
+                    ));
+
+            if (projectItem.getSaleType() != ItemSaleType.NORMAL) {
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "NORMAL 상품만 결제 확정 시 재고 차감이 가능합니다. (projectItemId=" + projectItem.getId() + ")"
+                );
+            }
+
+            Integer stockQty = projectItem.getStockQty();
+            int orderQty = orderItem.getQuantity();
+
+            if (stockQty == null) {
+                throw new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        "상품 재고 정보가 없어 결제 확정을 진행할 수 없습니다. (projectItemId=" + projectItem.getId() + ")"
+                );
+            }
+            if (stockQty < orderQty) {
+                throw new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        "재고가 부족하여 결제 확정을 진행할 수 없습니다. (projectItemId=" + projectItem.getId() + ")"
+                );
+            }
+
+            projectItem.updateStockQty(stockQty - orderQty);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        order.updateStatus(OrderStatus.PAID);
+        order.updatePaidAt(now);
+        order.updateStockDeductedAt(now);
+    }
+}


### PR DESCRIPTION
# 요약

아이템 재고 모델을 NORMAL 판매 기준으로 정리하고,  
관리자 입금 확인 시 주문을 PAID 상태로 확정하면서  
재고를 차감하는 결제 확정(Service) 흐름을 구현했습니다.

---

# 작업 내용

- ProjectItem에 `stockQty` 필드를 추가하여  
  NORMAL 아이템의 재고를 단일 기준으로 관리하도록 수정
- `targetQty`, `fundedQty`는 펀딩/공동구매 전용 필드로 역할 분리
- 일반 상품 수정 로직에서 재고(stockQty)가 우발적으로 변경되지 않도록  
  update 책임을 분리 (`updateStockQty` 단일 경로)
- 관리자 입금 확인 시 주문을 PAID 상태로 전환하는  
  `AdminOrderPaymentService` 구현
  - 단일 트랜잭션으로 상태 변경 + 재고 차감 처리
  - `stock_deducted_at`을 이용해 중복 결제 확정 방지
  - 재고 부족, 상태 불일치 등에 대한 한글 에러 메시지 처리
- 재고 차감 시 데드락 방지를 위해  
  Order → OrderItem → ProjectItem 순서로 잠금 처리

---

# 기타 (논의하고 싶은 부분)

- 환불(CANCELED / REFUND) 및 재고 복구 로직은  
  별도 브랜치에서 구현 예정
- GROUPBUY 상품에 대한 결제 확정 로직은  
  현재 의도적으로 미구현 상태입니다.

---

# 타 직군 전달 사항

- 입금 확인 버튼 클릭 시,  
  해당 주문은 즉시 PAID 상태로 전환되며 재고가 차감됩니다.
- 재고 부족 또는 상태 오류 발생 시  
  결제 확정이 거부되고 오류 메시지가 노출됩니다.