### PR TITLE
refactor: fundedQty nullable 허용 및 관련 검증 로직 정리

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemCreateRequestDto.java
@@ -41,7 +41,7 @@ public record AdminProjectItemCreateRequestDto(
         @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
         Integer targetQty,
 
-        @Schema(description = "현재 모금 수량 (미입력 시 0)", example = "0")
+        @Schema(description = "현재 모금 수량 (null 허용)", example = "0")
         Integer fundedQty,
 
         @NotNull

--- a/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/dto/request/AdminProjectItemUpdateRequestDto.java
@@ -41,8 +41,7 @@ public record AdminProjectItemUpdateRequestDto(
         @Schema(description = "목표 수량 (GROUPBUY 전용)", example = "100")
         Integer targetQty,
 
-        @NotNull
-        @Schema(description = "현재 모금 수량", example = "0")
+        @Schema(description = "현재 모금 수량 (null 허용)", example = "0")
         Integer fundedQty,
 
         @Schema(description = "아이템 타입", example = "PHYSICAL")

--- a/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/entity/ProjectItem.java
@@ -66,8 +66,8 @@ public class ProjectItem extends BaseTimeEntity {
     @Column(name = "target_qty")
     private Integer targetQty;
 
-    @Column(name = "funded_qty", nullable = false)
-    private int fundedQty;
+    @Column(name = "funded_qty")
+    private Integer fundedQty;
 
     @Column(name = "stock_qty")
     private Integer stockQty;
@@ -84,7 +84,7 @@ public class ProjectItem extends BaseTimeEntity {
             String thumbnailKey,
             String journalFileKey,
             Integer targetQty,
-            int fundedQty,
+            Integer fundedQty,
             Integer stockQty
     ) {
         this.project = project;
@@ -114,7 +114,7 @@ public class ProjectItem extends BaseTimeEntity {
             String thumbnailKey,
             String journalFileKey,
             Integer targetQty,
-            int fundedQty
+            Integer fundedQty
     ) {
         this(
                 project,
@@ -144,7 +144,7 @@ public class ProjectItem extends BaseTimeEntity {
             String thumbnailKey,
             String journalFileKey,
             Integer targetQty,
-            int fundedQty,
+            Integer fundedQty,
             Integer stockQty
     ) {
         this.name = name;
@@ -174,7 +174,7 @@ public class ProjectItem extends BaseTimeEntity {
             String thumbnailKey,
             String journalFileKey,
             Integer targetQty,
-            int fundedQty,
+            Integer fundedQty,
             Integer stockQty
     ) {
         updateInternal(
@@ -204,7 +204,7 @@ public class ProjectItem extends BaseTimeEntity {
             String thumbnailKey,
             String journalFileKey,
             Integer targetQty,
-            int fundedQty
+            Integer fundedQty
     ) {
         updateInternal(
                 name,

--- a/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/service/AdminItemService.java
@@ -444,11 +444,10 @@ public class AdminItemService {
                         "targetQty must be null for DIGITAL_JOURNAL"
                 );
             }
-            int normalizedFundedQty = fundedQty == null ? 0 : fundedQty;
-            if (normalizedFundedQty != 0) {
+            if (fundedQty != null && fundedQty != 0) {
                 throw new ResponseStatusException(
                         HttpStatus.UNPROCESSABLE_ENTITY,
-                        "fundedQty must be 0 for DIGITAL_JOURNAL"
+                        "fundedQty must be null or 0 for DIGITAL_JOURNAL"
                 );
             }
             String normalizedJournalKey = toNonBlankString(journalFileKey);
@@ -459,7 +458,7 @@ public class AdminItemService {
                 );
             }
             String normalizedThumbnailKey = toNonBlankString(thumbnailKey);
-            return new NormalizedItemRequest(itemType, null, 0, normalizedJournalKey, normalizedThumbnailKey, null);
+            return new NormalizedItemRequest(itemType, null, fundedQty, normalizedJournalKey, normalizedThumbnailKey, null);
         }
 
         String normalizedThumbnailKey = toNonBlankString(thumbnailKey);
@@ -477,8 +476,7 @@ public class AdminItemService {
             );
         }
 
-        int normalizedFundedQty = fundedQty == null ? 0 : fundedQty;
-        if (normalizedFundedQty < 0) {
+        if (fundedQty != null && fundedQty < 0) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "fundedQty must be >= 0");
         }
 
@@ -512,7 +510,7 @@ public class AdminItemService {
         return new NormalizedItemRequest(
                 itemType,
                 normalizedTargetQty,
-                normalizedFundedQty,
+                fundedQty,
                 null,
                 normalizedThumbnailKey,
                 normalizedStockQty
@@ -726,19 +724,20 @@ public class AdminItemService {
             return new GroupbuyInfo(null, null, null, null);
         }
         Integer targetQty = item.getTargetQty();
-        int fundedQty = item.getFundedQty();
+        Integer fundedQty = item.getFundedQty();
+        int fundedQtyValue = fundedQty == null ? 0 : fundedQty;
         double rate = 0.0;
         if (targetQty != null && targetQty > 0) {
-            rate = (double) fundedQty / targetQty * 100.0;
+            rate = (double) fundedQtyValue / targetQty * 100.0;
         }
-        int remainingQty = targetQty == null ? 0 : Math.max(targetQty - fundedQty, 0);
+        int remainingQty = targetQty == null ? 0 : Math.max(targetQty - fundedQtyValue, 0);
         return new GroupbuyInfo(targetQty, fundedQty, rate, remainingQty);
     }
 
     private record NormalizedItemRequest(
             ItemType itemType,
             Integer targetQty,
-            int fundedQty,
+            Integer fundedQty,
             String journalFileKey,
             String thumbnailKey,
             Integer stockQty

--- a/src/main/java/com/example/cowmjucraft/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/item/service/ItemService.java
@@ -222,12 +222,13 @@ public class ItemService {
             return new GroupbuyInfo(null, null, null, null);
         }
         Integer targetQty = item.getTargetQty();
-        int fundedQty = item.getFundedQty();
+        Integer fundedQty = item.getFundedQty();
+        int fundedQtyValue = fundedQty == null ? 0 : fundedQty;
         double rate = 0.0;
         if (targetQty != null && targetQty > 0) {
-            rate = (double) fundedQty / targetQty * 100.0;
+            rate = (double) fundedQtyValue / targetQty * 100.0;
         }
-        int remainingQty = targetQty == null ? 0 : Math.max(targetQty - fundedQty, 0);
+        int remainingQty = targetQty == null ? 0 : Math.max(targetQty - fundedQtyValue, 0);
         return new GroupbuyInfo(targetQty, fundedQty, rate, remainingQty);
     }
 


### PR DESCRIPTION
# 요약

 fundedQty를 nullable로 허용하도록 엔티티/검증/조회 계산 로직을 정리했습니다.

  # 작업 내용

  - [x] ProjectItem.fundedQty를 int + nullable = false에서 Integer nullable로 변경
  - [x] fundedQty null 강제 지점 제거
      - 수정 DTO의 @NotNull 제거
      - admin normalize 로직의 null -> 0 강제 제거
  - [x] 그룹바이 달성률/남은수량 계산은 null-safe로 보정(계산 시에만 0 처리)

