### PR TITLE
Feat/order confirm page

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/order/controller/admin/AdminOrderController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/controller/admin/AdminOrderController.java
@@ -1,26 +1,21 @@
 package com.example.cowmjucraft.domain.order.controller.admin;
 
 import com.example.cowmjucraft.domain.order.dto.request.AdminOrderCancelRequestDto;
-import com.example.cowmjucraft.domain.order.dto.response.AdminOrderListItemResponseDto;
-import com.example.cowmjucraft.domain.order.dto.response.AdminOrderStatusResponseDto;
-import com.example.cowmjucraft.domain.order.dto.response.OrderDetailResponseDto;
+import com.example.cowmjucraft.domain.order.dto.request.AdminOrderCompletePageUpsertRequestDto;
+import com.example.cowmjucraft.domain.order.dto.response.*;
 import com.example.cowmjucraft.domain.order.entity.OrderStatus;
+import com.example.cowmjucraft.domain.order.service.AdminOrderCompletePageService;
 import com.example.cowmjucraft.domain.order.service.AdminOrderPaymentService;
 import com.example.cowmjucraft.domain.order.service.AdminOrderQueryService;
 import com.example.cowmjucraft.domain.order.service.AdminOrderRefundService;
 import com.example.cowmjucraft.global.response.ApiResponse;
 import com.example.cowmjucraft.global.response.ApiResult;
 import com.example.cowmjucraft.global.response.type.SuccessType;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -30,6 +25,7 @@ public class AdminOrderController implements AdminOrderControllerDocs {
     private final AdminOrderQueryService adminOrderQueryService;
     private final AdminOrderPaymentService adminOrderPaymentService;
     private final AdminOrderRefundService adminOrderRefundService;
+    private final AdminOrderCompletePageService adminOrderCompletePageService;
 
     @GetMapping("/orders")
     @Override
@@ -43,6 +39,26 @@ public class AdminOrderController implements AdminOrderControllerDocs {
     @Override
     public ResponseEntity<ApiResult<OrderDetailResponseDto>> getOrderDetail(@PathVariable Long orderId) {
         return ApiResponse.of(SuccessType.SUCCESS, adminOrderQueryService.getOrderDetail(orderId));
+    }
+
+    @GetMapping("/admin/orders/complete-page")
+    @Override
+    public ResponseEntity<ApiResult<AdminOrderCompletePageResponseDto>> getOrderCompletePage() {
+        return ApiResponse.of(
+                SuccessType.SUCCESS,
+                adminOrderCompletePageService.getOrderCompletePage()
+        );
+    }
+
+    @PutMapping("/admin/orders/complete-page")
+    @Override
+    public ResponseEntity<ApiResult<AdminOrderCompletePageResponseDto>> upsertOrderCompletePage(
+            @Valid @RequestBody AdminOrderCompletePageUpsertRequestDto request
+    ) {
+        return ApiResponse.of(
+                SuccessType.SUCCESS,
+                adminOrderCompletePageService.upsertOrderCompletePage(request)
+        );
     }
 
     @PostMapping("/orders/{orderId}/confirm-paid")

--- a/src/main/java/com/example/cowmjucraft/domain/order/controller/admin/AdminOrderController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/controller/admin/AdminOrderController.java
@@ -41,7 +41,7 @@ public class AdminOrderController implements AdminOrderControllerDocs {
         return ApiResponse.of(SuccessType.SUCCESS, adminOrderQueryService.getOrderDetail(orderId));
     }
 
-    @GetMapping("/admin/orders/complete-page")
+    @GetMapping("/orders/complete-page")
     @Override
     public ResponseEntity<ApiResult<AdminOrderCompletePageResponseDto>> getOrderCompletePage() {
         return ApiResponse.of(
@@ -50,7 +50,7 @@ public class AdminOrderController implements AdminOrderControllerDocs {
         );
     }
 
-    @PutMapping("/admin/orders/complete-page")
+    @PutMapping("/orders/complete-page")
     @Override
     public ResponseEntity<ApiResult<AdminOrderCompletePageResponseDto>> upsertOrderCompletePage(
             @Valid @RequestBody AdminOrderCompletePageUpsertRequestDto request

--- a/src/main/java/com/example/cowmjucraft/domain/order/controller/admin/AdminOrderControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/controller/admin/AdminOrderControllerDocs.java
@@ -1,6 +1,8 @@
 package com.example.cowmjucraft.domain.order.controller.admin;
 
 import com.example.cowmjucraft.domain.order.dto.request.AdminOrderCancelRequestDto;
+import com.example.cowmjucraft.domain.order.dto.request.AdminOrderCompletePageUpsertRequestDto;
+import com.example.cowmjucraft.domain.order.dto.response.AdminOrderCompletePageResponseDto;
 import com.example.cowmjucraft.domain.order.dto.response.AdminOrderListItemResponseDto;
 import com.example.cowmjucraft.domain.order.dto.response.AdminOrderStatusResponseDto;
 import com.example.cowmjucraft.domain.order.dto.response.OrderDetailResponseDto;
@@ -39,6 +41,38 @@ public interface AdminOrderControllerDocs {
     ResponseEntity<ApiResult<OrderDetailResponseDto>> getOrderDetail(
             @Parameter(description = "주문 ID", example = "1")
             Long orderId
+    );
+
+    @Operation(summary = "관리자 주문 완료 페이지 조회", description = "관리자가 주문 완료 페이지 설정 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))),
+            @ApiResponse(responseCode = "404", description = "주문 완료 페이지 설정을 찾을 수 없음")
+    })
+    ResponseEntity<ApiResult<AdminOrderCompletePageResponseDto>> getOrderCompletePage();
+
+    @Operation(summary = "관리자 주문 완료 페이지 저장/수정", description = "관리자가 주문 완료 페이지 설정 정보를 저장하거나 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "처리 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))),
+            @ApiResponse(responseCode = "400", description = "필수 입력값이 누락됨")
+    })
+    ResponseEntity<ApiResult<AdminOrderCompletePageResponseDto>> upsertOrderCompletePage(@RequestBody(
+                    required = true,
+                    description = "관리자 주문 완료 페이지 저장/수정 요청",
+                    content = @Content(
+                            schema = @Schema(implementation = AdminOrderCompletePageUpsertRequestDto.class),
+                            examples = @ExampleObject(
+                                    name = "admin-order-complete-page-upsert-request",
+                                    value = """
+                                        {
+                                          "messageTitle": "주문이 완료되었습니다.",
+                                          "messageDescription": "입금 기한 내에 계좌이체를 완료해 주세요.",
+                                          "paymentInformation": "국민은행 123456-78-901234 / 예금주: 명지공방"
+                                        }
+                                        """
+                            )
+                    )
+            )
+            AdminOrderCompletePageUpsertRequestDto request
     );
 
     @Operation(summary = "관리자 결제 확정", description = "입금 대기(PENDING_DEPOSIT) 주문을 결제 확정(PAID) 처리하고, 조회 토큰을 갱신합니다.")

--- a/src/main/java/com/example/cowmjucraft/domain/order/controller/client/ClientOrderController.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/controller/client/ClientOrderController.java
@@ -2,13 +2,11 @@ package com.example.cowmjucraft.domain.order.controller.client;
 
 import com.example.cowmjucraft.domain.order.dto.request.OrderCreateRequestDto;
 import com.example.cowmjucraft.domain.order.dto.request.OrderLookupRequestDto;
+import com.example.cowmjucraft.domain.order.dto.response.OrderCompletePageResponseDto;
 import com.example.cowmjucraft.domain.order.dto.response.OrderCreateResponseDto;
 import com.example.cowmjucraft.domain.order.dto.response.OrderDetailResponseDto;
 import com.example.cowmjucraft.domain.order.dto.response.OrderLookupIdAvailabilityResponseDto;
-import com.example.cowmjucraft.domain.order.service.OrderCreateService;
-import com.example.cowmjucraft.domain.order.service.OrderDetailQueryService;
-import com.example.cowmjucraft.domain.order.service.OrderLookupIdService;
-import com.example.cowmjucraft.domain.order.service.OrderQueryByTokenService;
+import com.example.cowmjucraft.domain.order.service.*;
 import com.example.cowmjucraft.global.response.ApiResponse;
 import com.example.cowmjucraft.global.response.ApiResult;
 import com.example.cowmjucraft.global.response.type.SuccessType;
@@ -31,6 +29,7 @@ public class ClientOrderController implements ClientOrderControllerDocs {
     private final OrderLookupIdService orderLookupIdService;
     private final OrderDetailQueryService orderDetailQueryService;
     private final OrderQueryByTokenService orderQueryByTokenService;
+    private final OrderCompletePageService orderCompletePageService;
 
     @PostMapping("/orders")
     @Override
@@ -63,5 +62,12 @@ public class ClientOrderController implements ClientOrderControllerDocs {
     @Override
     public ResponseEntity<ApiResult<OrderDetailResponseDto>> viewOrderByToken(@RequestParam("token") String token) {
         return ApiResponse.of(SuccessType.SUCCESS, orderQueryByTokenService.getOrderDetailByToken(token));
+    }
+
+    @GetMapping("/orders/complete-page")
+    @Override
+    public ResponseEntity<ApiResult<OrderCompletePageResponseDto>> getOrderCompletePage(@RequestParam("token") String token) {
+        return ApiResponse.of(SuccessType.SUCCESS, orderCompletePageService.getOrderCompletePage(token)
+        );
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/order/controller/client/ClientOrderControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/controller/client/ClientOrderControllerDocs.java
@@ -2,6 +2,7 @@ package com.example.cowmjucraft.domain.order.controller.client;
 
 import com.example.cowmjucraft.domain.order.dto.request.OrderCreateRequestDto;
 import com.example.cowmjucraft.domain.order.dto.request.OrderLookupRequestDto;
+import com.example.cowmjucraft.domain.order.dto.response.OrderCompletePageResponseDto;
 import com.example.cowmjucraft.domain.order.dto.response.OrderCreateResponseDto;
 import com.example.cowmjucraft.domain.order.dto.response.OrderDetailResponseDto;
 import com.example.cowmjucraft.domain.order.dto.response.OrderLookupIdAvailabilityResponseDto;
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Order - Public", description = "비회원 주문 API")
 public interface ClientOrderControllerDocs {
@@ -231,5 +233,38 @@ public interface ClientOrderControllerDocs {
     ResponseEntity<ApiResult<OrderDetailResponseDto>> viewOrderByToken(
             @Parameter(description = "이메일 링크 조회 토큰", required = true, example = "raw-view-token-string")
             String token
+    );
+
+    @Operation(
+            summary = "주문 완료 페이지 조회",
+            description = "조회 토큰으로 주문 완료 페이지 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "주문 완료 페이지 조회 성공",
+                    content = @Content(schema = @Schema(implementation = OrderCompletePageResponseDto.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "조회 토큰이 누락되었습니다."
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "유효하지 않은 조회 링크이거나 주문 완료 페이지 설정이 존재하지 않습니다."
+            ),
+            @ApiResponse(
+                    responseCode = "410",
+                    description = "만료되었거나 폐기된 조회 링크입니다."
+            )
+    })
+    ResponseEntity<ApiResult<OrderCompletePageResponseDto>> getOrderCompletePage(
+            @Parameter(
+                    name = "token",
+                    description = "주문 조회 토큰",
+                    required = true,
+                    example = "sample-order-view-token"
+            )
+            @RequestParam("token") String token
     );
 }

--- a/src/main/java/com/example/cowmjucraft/domain/order/dto/request/AdminOrderCompletePageUpsertRequestDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/dto/request/AdminOrderCompletePageUpsertRequestDto.java
@@ -1,0 +1,27 @@
+package com.example.cowmjucraft.domain.order.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "관리자 주문 완료 페이지 저장/수정 요청 DTO")
+public record AdminOrderCompletePageUpsertRequestDto(
+
+        @NotBlank
+        @Schema(description = "주문 완료 메시지 제목", example = "주문이 완료되었습니다.")
+        String messageTitle,
+
+        @Schema(
+                description = "주문 완료 메시지 설명",
+                example = "입금 기한 내에 계좌이체를 완료해 주세요.",
+                nullable = true
+        )
+        String messageDescription,
+
+        @NotBlank
+        @Schema(
+                description = "결제 정보",
+                example = "국민은행 123456-78-901234 / 예금주: 명지공방"
+        )
+        String paymentInformation
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/dto/response/AdminOrderCompletePageResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/dto/response/AdminOrderCompletePageResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.cowmjucraft.domain.order.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 주문 완료 페이지 응답 DTO")
+public record AdminOrderCompletePageResponseDto(
+
+        @Schema(description = "주문 완료 페이지 ID", example = "1")
+        Long id,
+
+        @Schema(description = "주문 완료 메시지 제목", example = "주문이 완료되었습니다.")
+        String messageTitle,
+
+        @Schema(
+                description = "주문 완료 메시지 설명",
+                example = "입금 기한 내에 계좌이체를 완료해 주세요.",
+                nullable = true
+        )
+        String messageDescription,
+
+        @Schema(
+                description = "결제 정보",
+                example = "국민은행 123456-78-901234 / 예금주: 명지공방"
+        )
+        String paymentInformation
+) {
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/dto/response/OrderCompletePageResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/dto/response/OrderCompletePageResponseDto.java
@@ -1,0 +1,75 @@
+package com.example.cowmjucraft.domain.order.dto.response;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "주문 완료 페이지 응답 DTO")
+public record OrderCompletePageResponseDto(
+
+        @Schema(description = "주문 완료 메시지 제목", example = "주문이 완료되었습니다.")
+        String messageTitle,
+
+        @Schema(
+                description = "주문 완료 메시지 설명",
+                example = "입금 기한 내에 계좌이체를 완료해 주세요.",
+                nullable = true
+        )
+        String messageDescription,
+
+        @Schema(
+                description = "결제 정보",
+                example = "국민은행 123456-78-901234 / 예금주: 명지공방"
+        )
+        String paymentInformation,
+
+        @Schema(description = "주문 정보")
+        OrderInfo order,
+
+        @ArraySchema(arraySchema = @Schema(description = "주문 상품 목록"))
+        List<ItemInfo> items
+) {
+
+    public record OrderInfo(
+            @Schema(description = "주문 번호", example = "ORD-20260207190000-123456")
+            String orderNo,
+
+            @Schema(description = "주문 상태", example = "PENDING_DEPOSIT")
+            String status,
+
+            @Schema(description = "상품 합계 금액", example = "24000")
+            int totalAmount,
+
+            @Schema(description = "배송비", example = "0")
+            int shippingFee,
+
+            @Schema(description = "최종 결제 금액", example = "24000")
+            int finalAmount,
+
+            @Schema(description = "입금 기한", example = "2026-02-08T23:59:59")
+            LocalDateTime depositDeadline,
+
+            @Schema(description = "주문 생성 시각", example = "2026-02-07T19:00:00")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    public record ItemInfo(
+            @Schema(description = "프로젝트 상품 ID", example = "1")
+            Long projectItemId,
+
+            @Schema(description = "상품명 스냅샷", example = "후드티")
+            String itemNameSnapshot,
+
+            @Schema(description = "수량", example = "2")
+            int quantity,
+
+            @Schema(description = "단가", example = "12000")
+            int unitPrice,
+
+            @Schema(description = "라인 금액", example = "24000")
+            int lineAmount
+    ) {
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/entity/OrderCompletePage.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/entity/OrderCompletePage.java
@@ -1,0 +1,52 @@
+package com.example.cowmjucraft.domain.order.entity;
+
+import com.example.cowmjucraft.domain.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "order_complete_pages")
+public class OrderCompletePage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "message_title", nullable = false, length = 200)
+    private String messageTitle;
+
+    @Column(name = "message_description", length = 500)
+    private String messageDescription;
+
+    @Column(name = "payment_information", nullable = false, length = 1000)
+    private String paymentInformation;
+
+    public OrderCompletePage(
+            String messageTitle,
+            String messageDescription,
+            String paymentInformation
+    ) {
+        this.messageTitle = messageTitle;
+        this.messageDescription = messageDescription;
+        this.paymentInformation = paymentInformation;
+    }
+
+    public void update(
+            String messageTitle,
+            String messageDescription,
+            String paymentInformation
+    ) {
+        this.messageTitle = messageTitle;
+        this.messageDescription = messageDescription;
+        this.paymentInformation = paymentInformation;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/exception/OrderErrorType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/exception/OrderErrorType.java
@@ -13,6 +13,7 @@ public enum OrderErrorType implements ErrorCode {
     BUYER_NOT_FOUND(404, "주문자 정보를 찾을 수 없습니다."),
     FULFILLMENT_NOT_FOUND(404, "수령 정보를 찾을 수 없습니다."),
     INVALID_VIEW_TOKEN(404, "유효하지 않은 조회 링크입니다."),
+    ORDER_COMPLETE_PAGE_NOT_FOUND(404, "주문 완료 페이지 설정을 찾을 수 없습니다."),
 
     EXPIRED_VIEW_TOKEN(410, "만료되었거나 폐기된 조회 링크입니다."),
 

--- a/src/main/java/com/example/cowmjucraft/domain/order/repository/OrderCompletePageRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/repository/OrderCompletePageRepository.java
@@ -1,0 +1,10 @@
+package com.example.cowmjucraft.domain.order.repository;
+
+import com.example.cowmjucraft.domain.order.entity.OrderCompletePage;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderCompletePageRepository extends JpaRepository<OrderCompletePage, Long> {
+
+    Optional<OrderCompletePage> findFirstByOrderByIdAsc();
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/AdminOrderCompletePageService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/AdminOrderCompletePageService.java
@@ -1,0 +1,84 @@
+package com.example.cowmjucraft.domain.order.service;
+
+import com.example.cowmjucraft.domain.order.dto.request.AdminOrderCompletePageUpsertRequestDto;
+import com.example.cowmjucraft.domain.order.dto.response.AdminOrderCompletePageResponseDto;
+import com.example.cowmjucraft.domain.order.entity.OrderCompletePage;
+import com.example.cowmjucraft.domain.order.exception.OrderErrorType;
+import com.example.cowmjucraft.domain.order.exception.OrderException;
+import com.example.cowmjucraft.domain.order.repository.OrderCompletePageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminOrderCompletePageService {
+
+    private final OrderCompletePageRepository orderCompletePageRepository;
+
+    @Transactional(readOnly = true)
+    public AdminOrderCompletePageResponseDto getOrderCompletePage() {
+        OrderCompletePage orderCompletePage = orderCompletePageRepository.findFirstByOrderByIdAsc()
+                .orElseThrow(() -> new OrderException(OrderErrorType.ORDER_COMPLETE_PAGE_NOT_FOUND));
+
+        return toResponse(orderCompletePage);
+    }
+
+    @Transactional
+    public AdminOrderCompletePageResponseDto upsertOrderCompletePage(
+            AdminOrderCompletePageUpsertRequestDto request
+    ) {
+        String messageTitle = normalizeRequiredText(request.messageTitle(), "메시지 제목");
+        String messageDescription = trimToNull(request.messageDescription());
+        String paymentInformation = normalizeRequiredText(request.paymentInformation(), "결제 정보");
+
+        OrderCompletePage orderCompletePage = orderCompletePageRepository.findFirstByOrderByIdAsc()
+                .orElse(null);
+
+        if (orderCompletePage == null) {
+            orderCompletePage = orderCompletePageRepository.save(
+                    new OrderCompletePage(
+                            messageTitle,
+                            messageDescription,
+                            paymentInformation
+                    )
+            );
+        } else {
+            orderCompletePage.update(
+                    messageTitle,
+                    messageDescription,
+                    paymentInformation
+            );
+        }
+
+        return toResponse(orderCompletePage);
+    }
+
+    private AdminOrderCompletePageResponseDto toResponse(OrderCompletePage orderCompletePage) {
+        return new AdminOrderCompletePageResponseDto(
+                orderCompletePage.getId(),
+                orderCompletePage.getMessageTitle(),
+                orderCompletePage.getMessageDescription(),
+                orderCompletePage.getPaymentInformation()
+        );
+    }
+
+    private String normalizeRequiredText(String value, String fieldName) {
+        String normalized = trimToNull(value);
+        if (normalized == null) {
+            throw new OrderException(
+                    OrderErrorType.REQUIRED_FIELD_MISSING,
+                    fieldName + "은(는) 필수입니다."
+            );
+        }
+        return normalized;
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/OrderCompletePageService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/OrderCompletePageService.java
@@ -1,0 +1,57 @@
+package com.example.cowmjucraft.domain.order.service;
+
+import com.example.cowmjucraft.domain.order.dto.response.OrderCompletePageResponseDto;
+import com.example.cowmjucraft.domain.order.entity.Order;
+import com.example.cowmjucraft.domain.order.entity.OrderCompletePage;
+import com.example.cowmjucraft.domain.order.entity.OrderItem;
+import com.example.cowmjucraft.domain.order.exception.OrderErrorType;
+import com.example.cowmjucraft.domain.order.exception.OrderException;
+import com.example.cowmjucraft.domain.order.repository.OrderCompletePageRepository;
+import com.example.cowmjucraft.domain.order.repository.OrderItemRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderCompletePageService {
+
+    private final OrderCompletePageRepository orderCompletePageRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final OrderViewTokenService orderViewTokenService;
+
+    @Transactional(readOnly = true)
+    public OrderCompletePageResponseDto getOrderCompletePage(String rawToken) {
+        Order order = orderViewTokenService.getValidOrder(rawToken);
+
+        OrderCompletePage orderCompletePage = orderCompletePageRepository.findFirstByOrderByIdAsc()
+                .orElseThrow(() -> new OrderException(OrderErrorType.ORDER_COMPLETE_PAGE_NOT_FOUND));
+
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrderIdOrderByProjectItemIdAsc(order.getId());
+
+        return new OrderCompletePageResponseDto(
+                orderCompletePage.getMessageTitle(),
+                orderCompletePage.getMessageDescription(),
+                orderCompletePage.getPaymentInformation(),
+                new OrderCompletePageResponseDto.OrderInfo(
+                        order.getOrderNo(),
+                        order.getStatus().name(),
+                        order.getTotalAmount(),
+                        order.getShippingFee(),
+                        order.getFinalAmount(),
+                        order.getDepositDeadline(),
+                        order.getCreatedAt()
+                ),
+                orderItems.stream()
+                        .map(orderItem -> new OrderCompletePageResponseDto.ItemInfo(
+                                orderItem.getProjectItem().getId(),
+                                orderItem.getItemNameSnapshot(),
+                                orderItem.getQuantity(),
+                                orderItem.getUnitPrice(),
+                                orderItem.getLineAmount()
+                        ))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/OrderViewTokenService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/OrderViewTokenService.java
@@ -68,6 +68,26 @@ public class OrderViewTokenService {
         return base + path + "?token=" + token;
     }
 
+    @Transactional(readOnly = true)
+    public Order getValidOrder(String rawToken) {
+        if (rawToken == null || rawToken.trim().isEmpty()) {
+            throw new OrderException(OrderErrorType.VIEW_TOKEN_REQUIRED);
+        }
+
+        String tokenHash = hashToken(rawToken);
+
+        OrderViewToken orderViewToken = orderViewTokenRepository.findByTokenHash(tokenHash)
+                .orElseThrow(() -> new OrderException(OrderErrorType.INVALID_VIEW_TOKEN));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (orderViewToken.getRevokedAt() != null || orderViewToken.getExpiresAt().isBefore(now)) {
+            throw new OrderException(OrderErrorType.EXPIRED_VIEW_TOKEN);
+        }
+
+        return orderViewToken.getOrder();
+    }
+
     private String generateRawToken() {
         byte[] bytes = new byte[32];
         SECURE_RANDOM.nextBytes(bytes);


### PR DESCRIPTION
# 요약
- 주문 완료 페이지 기능을 추가했습니다.
- 관리자가 주문 완료 페이지 문구 및 결제 정보를 조회/수정할 수 있도록 구현했습니다.
- 사용자가 조회 토큰으로 주문 완료 페이지를 조회할 수 있도록 구현했습니다.

# 작업 내용
- OrderCompletePage 엔티티 추가
- OrderCompletePageRepository 추가
- 주문 완료 페이지 관리자,사용자 dto 추가
- 주문 완료 페이지 관리자, 사용자 service 추가
- OrderViewTokenService에 유효 토큰 기반 주문 조회 로직 추가
- 관리자, 사용자의 API 및 Docs 추가
- OrderErrorType에 ORDER_COMPLETE_PAGE_NOT_FOUND 추가

# 타 직군 전달 사항
- 프런트는 주문 생성 후 발급된 조회 토큰으로 `/orders/complete-page?token=...` 조회가 가능합니다.
- messageDescription은 null 허용입니다.

# 기타
- 현재 주문 완료 페이지는 하나만 만들었습니다. 추후에 필요하다면, 각 상품이 각기 다른 주문 완료 페이지로 매핑되도록 확장하겠습니다.