### PR TITLE
feat: 주문 상세 조회 응답에 결제 정보 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/order/controller/client/ClientOrderControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/controller/client/ClientOrderControllerDocs.java
@@ -211,6 +211,7 @@ public interface ClientOrderControllerDocs {
                                                   "postalCode": "04524",
                                                   "deliveryMemo": "부재 시 문 앞에 놓아주세요"
                                                 },
+                                                "paymentInformation": "국민은행 123456-78-901234 / 예금주: 명지공방",
                                                 "items": [
                                                   {
                                                     "projectItemId": 1,

--- a/src/main/java/com/example/cowmjucraft/domain/order/dto/response/OrderDetailResponseDto.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/dto/response/OrderDetailResponseDto.java
@@ -16,6 +16,9 @@ public record OrderDetailResponseDto(
         @Schema(description = "수령/배송 정보")
         FulfillmentInfo fulfillment,
 
+        @Schema(description = "입금/결제 정보", example = "국민은행 123456-78-901234 / 예금주: 명지공방", nullable = true)
+        String paymentInformation,
+
         @ArraySchema(arraySchema = @Schema(description = "주문 상품 목록"))
         List<ItemInfo> items
 ) {

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/OrderDetailQueryService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/OrderDetailQueryService.java
@@ -1,20 +1,11 @@
 package com.example.cowmjucraft.domain.order.service;
 
 import com.example.cowmjucraft.domain.order.dto.response.OrderDetailResponseDto;
-import com.example.cowmjucraft.domain.order.entity.Order;
-import com.example.cowmjucraft.domain.order.entity.OrderAuth;
-import com.example.cowmjucraft.domain.order.entity.OrderBuyer;
-import com.example.cowmjucraft.domain.order.entity.OrderFulfillment;
-import com.example.cowmjucraft.domain.order.entity.OrderItem;
-import com.example.cowmjucraft.domain.order.entity.OrderViewToken;
+import com.example.cowmjucraft.domain.order.entity.*;
 import com.example.cowmjucraft.domain.order.exception.OrderErrorType;
 import com.example.cowmjucraft.domain.order.exception.OrderException;
-import com.example.cowmjucraft.domain.order.repository.OrderAuthRepository;
-import com.example.cowmjucraft.domain.order.repository.OrderBuyerRepository;
-import com.example.cowmjucraft.domain.order.repository.OrderFulfillmentRepository;
-import com.example.cowmjucraft.domain.order.repository.OrderItemRepository;
-import com.example.cowmjucraft.domain.order.repository.OrderRepository;
-import com.example.cowmjucraft.domain.order.repository.OrderViewTokenRepository;
+import com.example.cowmjucraft.domain.order.repository.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +25,7 @@ public class OrderDetailQueryService {
     private final OrderRepository orderRepository;
     private final OrderViewTokenService orderViewTokenService;
     private final PasswordEncoder passwordEncoder;
+    private final OrderCompletePageRepository orderCompletePageRepository;
 
     @Transactional(readOnly = true)
     public OrderDetailResponseDto getByLookupIdAndPassword(String lookupId, String password) {
@@ -82,6 +74,12 @@ public class OrderDetailQueryService {
         OrderFulfillment fulfillment = orderFulfillmentRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(OrderErrorType.FULFILLMENT_NOT_FOUND));
 
+        OrderCompletePage orderCompletePage = orderCompletePageRepository.findFirstByOrderByIdAsc()
+                .orElseThrow(() -> new OrderException(OrderErrorType.ORDER_COMPLETE_PAGE_NOT_FOUND));
+
+        String paymentInformation = orderCompletePage.getPaymentInformation();
+
+
         List<OrderDetailResponseDto.ItemInfo> items = orderItemRepository.findAllByOrderIdOrderByProjectItemIdAsc(orderId).stream()
                 .map(item -> new OrderDetailResponseDto.ItemInfo(
                         item.getProjectItem().getId(),
@@ -127,6 +125,7 @@ public class OrderDetailQueryService {
                         fulfillment.getPostalCode(),
                         fulfillment.getDeliveryMemo()
                 ),
+                paymentInformation,
                 items
         );
     }


### PR DESCRIPTION
# 요약
- 주문 상세 조회 응답에 결제 정보(paymentInformation)를 추가했습니다.
- 조회 아이디/비밀번호 기반 조회, 이메일 토큰 기반 조회, 관리자 주문 상세 조회에서 동일하게 결제 정보가 내려가도록 반영했습니다.

# 작업 내용
- [x] OrderDetailResponseDto에 paymentInformation 필드 추가
- [x] OrderDetailQueryService에서 OrderCompletePage의 paymentInformation을 조회하도록 수정
- [x] 주문 상세 응답 생성 시 paymentInformation을 함께 내려주도록 반영
- [x] 클라이언트 주문 상세 조회 응답 예시 문서 수정

# 타 직군 전달 사항
- `/api/orders/lookup`, `/api/orders/view`, `/api/admin/orders/{orderId}` 응답에 `paymentInformation`이 추가되었습니다.
- 결제 정보는 현재 `OrderCompletePage`에 저장된 값을 사용합니다.
- 따라서 관리자에서 주문 완료 페이지의 결제 정보를 수정하면 주문 상세 조회 응답에도 동일한 값이 반영됩니다.
- client 뿐 아니라 admin의 주문 상세 조회에도 paymentInformation이 추가되었습니다!!

# 기타
- 현재는 결제 정보를 `OrderCompletePage`에서 관리하도록 두었고, 추후 주문/결제 안내 설정이 확장되면 별도 설정으로 분리 리팩토링할 수 있습니다.