### PR TITLE
feat: 미인증 요청에 대한 401 응답 처리 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.cowmjucraft.global.config;
 
+import com.example.cowmjucraft.global.config.jwt.JwtAuthenticationEntryPoint;
 import com.example.cowmjucraft.global.config.jwt.JwtAuthenticationFilter;
 import com.example.cowmjucraft.global.config.jwt.JwtTokenProvider;
 import org.springframework.context.annotation.Bean;
@@ -17,7 +18,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter)
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter,
+            JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint)
             throws Exception {
 
         http
@@ -41,6 +43,7 @@ public class SecurityConfig {
                 )
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/example/cowmjucraft/global/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.example.cowmjucraft.global.config.jwt;
+
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.CommonErrorType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResult<?> body = ApiResult.error(CommonErrorType.UNAUTHORIZED);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}


### PR DESCRIPTION
 # 요약                                                                                                                                                                           
                                                                                                                                                                                   
  미인증 요청(토큰 없음)에 대해 403 대신 401을 반환하도록 AuthenticationEntryPoint를 추가했습니다.                                                                             
                                                                                                                                                                                  
  # 작업 내용                                                                                                                                                                      
                  
  - JwtAuthenticationEntryPoint 구현 — 미인증 요청 시 ApiResult 포맷으로 401 반환                                                                                              
  - SecurityConfig에 exceptionHandling으로 JwtAuthenticationEntryPoint 등록