### PR TITLE
fix: 주문 시각 UTC → KST 9시간 불일치 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN ./gradlew clean bootJar -x test
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   application:
     name: cowmjucraft
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
 
 server:
   port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: cowmjucraft
+  jackson:
+    time-zone: Asia/Seoul
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
# 요약

JVM 및 Hibernate timezone 미설정으로 발생하던 주문 시각 9시간 불일치 문제를 수정한다.

# 작업 내용

- [x] `Dockerfile` — JVM 실행 옵션에 `-Duser.timezone=Asia/Seoul` 추가
- [x] `application.yml` — `spring.jpa.properties.hibernate.jdbc.time_zone: Asia/Seoul` 추가

# 기타 (논의하고 싶은 부분)

**원인**
Docker 컨테이너 기본 timezone이 UTC이고, 기존 설정 어디에도 `Asia/Seoul` timezone이 명시되지 않아 JVM이 UTC로 실행됐다.
결과적으로 모든 `LocalDateTime.now()` 호출과 `@CreatedDate` / `@CreationTimestamp` 자동 기록 값이 KST보다 9시간 빠르게 저장됐다.

**영향 범위**
- 주문 생성/결제/취소/환불 시각 (`createdAt`, `paidAt`, `canceledAt` 등)
- 입금 기한 계산 (`depositDeadline`)
- 고객 이메일 표시 시각
- 주문 조회 토큰 만료 시각

**Breaking Change 없음** — 신규 저장분부터 KST 적용. 기존 UTC 저장 데이터는 별도 마이그레이션 논의 필요.

**추가 확인 필요 (코드 외)**
`SPRING_DATASOURCE_URL` 환경변수에 `serverTimezone=Asia/Seoul` 파라미터 포함 여부를 배포 환경에서 직접 확인해야 한다.

# 타 직군 전달 사항

없음

close #이슈번호