### PR TITLE
fix: 공동구매 상품 초과 주문 허용

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/order/service/AdminOrderPaymentService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/AdminOrderPaymentService.java
@@ -89,11 +89,7 @@ public class AdminOrderPaymentService {
         }
 
         if (projectItem.getSaleType() == ItemSaleType.GROUPBUY) {
-            Integer targetQty = projectItem.getTargetQty();
             int fundedQty = projectItem.getFundedQty() == null ? 0 : projectItem.getFundedQty();
-            if (targetQty == null || targetQty - fundedQty < orderQty) {
-                throw new OrderException(OrderErrorType.INSUFFICIENT_STOCK, "projectItemId=" + projectItem.getId());
-            }
             projectItem.updateFundedQty(fundedQty + orderQty);
             return;
         }

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/OrderCreateService.java
@@ -247,11 +247,6 @@ public class OrderCreateService {
         }
 
         if (projectItem.getSaleType() == ItemSaleType.GROUPBUY) {
-            Integer targetQty = projectItem.getTargetQty();
-            int fundedQty = projectItem.getFundedQty() == null ? 0 : projectItem.getFundedQty();
-            if (targetQty == null || targetQty - fundedQty < quantity) {
-                throw new OrderException(OrderErrorType.INSUFFICIENT_STOCK, "projectItemId=" + projectItem.getId());
-            }
             return;
         }
 

--- a/src/test/java/com/example/cowmjucraft/domain/order/service/AdminOrderPaymentServiceTest.java
+++ b/src/test/java/com/example/cowmjucraft/domain/order/service/AdminOrderPaymentServiceTest.java
@@ -77,6 +77,26 @@ class AdminOrderPaymentServiceTest {
         assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
     }
 
+    @Test
+    void confirmPaid_allowsGroupbuyFundedQuantityOverTargetQuantity() {
+        Order order = order();
+        ProjectItem item = groupbuyItem(1L, 100, 98);
+        OrderItem orderItem = new OrderItem(order, item, 3, 10_000, 30_000, "공동구매 상품");
+        OrderBuyer buyer = buyer(order);
+
+        when(orderRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(order));
+        when(orderItemRepository.findAllByOrderIdOrderByProjectItemIdAsc(10L)).thenReturn(List.of(orderItem));
+        when(projectItemRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(item));
+        when(orderBuyerRepository.findById(10L)).thenReturn(Optional.of(buyer));
+        when(orderViewTokenService.rotateToken(any(Order.class), any())).thenReturn("raw-token");
+        when(orderViewTokenService.buildOrderViewUrl("raw-token")).thenReturn("https://example.com/orders/view?token=raw-token");
+
+        adminOrderPaymentService.confirmPaid(10L);
+
+        assertThat(item.getFundedQty()).isEqualTo(101);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+    }
+
     private Order order() {
         Order order = new Order(
                 "ORD-20260505120000-123456",

--- a/src/test/java/com/example/cowmjucraft/domain/order/service/OrderCreateServiceTest.java
+++ b/src/test/java/com/example/cowmjucraft/domain/order/service/OrderCreateServiceTest.java
@@ -12,8 +12,6 @@ import com.example.cowmjucraft.domain.order.dto.request.OrderCreateRequestDto;
 import com.example.cowmjucraft.domain.order.entity.Order;
 import com.example.cowmjucraft.domain.order.entity.OrderBuyerType;
 import com.example.cowmjucraft.domain.order.entity.OrderFulfillmentMethod;
-import com.example.cowmjucraft.domain.order.exception.OrderErrorType;
-import com.example.cowmjucraft.domain.order.exception.OrderException;
 import com.example.cowmjucraft.domain.order.repository.OrderAuthRepository;
 import com.example.cowmjucraft.domain.order.repository.OrderBuyerRepository;
 import com.example.cowmjucraft.domain.order.repository.OrderFulfillmentRepository;
@@ -29,9 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -95,17 +91,23 @@ class OrderCreateServiceTest {
     }
 
     @Test
-    void createOrder_rejectsGroupbuyItemOverRemainingQuantity() {
+    void createOrder_allowsGroupbuyItemOverRemainingQuantity() {
         ProjectItem item = groupbuyItem(1L, 100, 40);
         when(orderAuthRepository.existsByLookupId("guest-mju-001")).thenReturn(false);
         when(projectItemRepository.findById(1L)).thenReturn(Optional.of(item));
+        when(orderRepository.existsByOrderNo(any())).thenReturn(false);
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> {
+            Order order = invocation.getArgument(0);
+            ReflectionTestUtils.setField(order, "id", 10L);
+            return order;
+        });
+        when(passwordEncoder.encode("Pa$$w0rd!")).thenReturn("encoded-password");
+        when(orderViewTokenService.issueNewToken(any(Order.class), any())).thenReturn("raw-token");
+        when(orderViewTokenService.buildOrderViewUrl("raw-token")).thenReturn("https://example.com/orders/view?token=raw-token");
 
-        assertThatThrownBy(() -> orderCreateService.createOrder(request(61)))
-                .isInstanceOf(OrderException.class)
-                .extracting(exception -> ((OrderException) exception).getErrorCode())
-                .isEqualTo(OrderErrorType.INSUFFICIENT_STOCK);
+        orderCreateService.createOrder(request(61));
 
-        verify(orderRepository, never()).save(any());
+        verify(orderItemRepository).saveAll(any());
     }
 
     private ProjectItem groupbuyItem(Long id, int targetQty, int fundedQty) {


### PR DESCRIPTION
# 요약

공동구매 상품이 목표 수량을 초과해도 주문 생성 및 입금 확정이 가능하도록 수정했습니다.

# 작업 내용

- [x] 공동구매 상품 주문 생성 시 목표 수량 대비 잔여 수량 검증 제거
- [x] 공동구매 상품 입금 확정 시 목표 수량 초과 검증 제거
- [x] 입금 확정 시 공동구매 상품의 fundedQty 증가 로직 유지
- [x] 공동구매 목표 수량 초과 주문 생성 및 입금 확정 테스트 반영

# 기타 (논의하고 싶은 부분)

공동구매 응답의 remainingQty는 목표 수량 초과 시 0으로 표시되는데, achievementRate는 실제 모금 수량 기준으로 계산되어 100%를 초과해 표시될 수 있습니다.
