### PR TITLE
feat: 지원서 기본 정보 섹션 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/recruit/controller/admin/FormAdminControllerDocs.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/controller/admin/FormAdminControllerDocs.java
@@ -71,7 +71,9 @@ public interface FormAdminControllerDocs {
             summary = "문항 추가",
             description = """
                     Form에 문항(FormQuestion)을 추가합니다.
-                    - sectionType=COMMON이면 departmentType은 null이어야 합니다.
+                    - sectionType은 BASIC, COMMON, DEPARTMENT 중 하나입니다.
+                    - sectionType=BASIC 또는 COMMON이면 departmentType은 null이어야 합니다.
+                    - sectionType=DEPARTMENT이면 departmentType이 필요합니다.
                     - answerType!=SELECT이면 selectOptions는 null이어야 합니다.
                     """
     )
@@ -140,7 +142,7 @@ public interface FormAdminControllerDocs {
 
     // ------------------------------------------------------------
 
-    @Operation(summary = "문항 복사(덮어쓰기)", description = "sourceFormId의 문항을 targetFormId로 복사하며, target의 기존 문항은 전부 삭제 후 복사합니다.")
+    @Operation(summary = "문항 복사(덮어쓰기)", description = "sourceFormId의 문항과 안내문을 targetFormId로 복사하며, target의 기존 문항/안내문은 전부 삭제 후 복사합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "400", description = "요청 규칙 위반(같은 form 복사 등)"),
@@ -159,7 +161,9 @@ public interface FormAdminControllerDocs {
             summary = "안내문 추가",
             description = """
                 Form에 안내문(Notice)을 추가합니다.
-                - sectionType=COMMON이면 departmentType은 null이어야 합니다.
+                - sectionType은 BASIC, COMMON, DEPARTMENT 중 하나입니다.
+                - sectionType=BASIC 또는 COMMON이면 departmentType은 null이어야 합니다.
+                - sectionType=DEPARTMENT이면 departmentType이 필요합니다.
                 """
     )
     @ApiResponses({

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/AnswerGroupsAdmin.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/AnswerGroupsAdmin.java
@@ -8,11 +8,13 @@ import java.util.Map;
 
 public class AnswerGroupsAdmin {
 
+    private final List<AnswerItem> basic;
     private final List<AnswerItem> common;
     private final List<AnswerItem> firstDepartment;
     private final List<AnswerItem> secondDepartment;
 
     public AnswerGroupsAdmin(Application application, List<Answer> answers, Map<String, String> urlMap) {
+        this.basic = new ArrayList<>();
         this.common = new ArrayList<>();
         this.firstDepartment = new ArrayList<>();
         this.secondDepartment = new ArrayList<>();
@@ -27,6 +29,11 @@ public class AnswerGroupsAdmin {
 
             if (formQuestion.getAnswerType() == AnswerType.FILE && key != null) {
                 fileUrl = urlMap.get(key);
+            }
+
+            if (formQuestion.getSectionType() == SectionType.BASIC) {
+                basic.add(new AnswerItem(formQuestion.getId(), answer.getValue(), fileUrl));
+                continue;
             }
 
             if (formQuestion.getSectionType() == SectionType.COMMON) {
@@ -47,6 +54,10 @@ public class AnswerGroupsAdmin {
 
     public List<AnswerItem> getCommon() {
         return common;
+    }
+
+    public List<AnswerItem> getBasic() {
+        return basic;
     }
 
     public List<AnswerItem> getFirstDepartment() {

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/ApplicationDetailAdminResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/ApplicationDetailAdminResponse.java
@@ -24,6 +24,7 @@ public class ApplicationDetailAdminResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    private List<AnswerItem> basicAnswers;
     private List<AnswerItem> commonAnswers;
     private List<AnswerItem> firstDepartmentAnswers;
     private List<AnswerItem> secondDepartmentAnswers;

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/response/ApplicationReadResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/response/ApplicationReadResponse.java
@@ -17,10 +17,12 @@ public record ApplicationReadResponse(
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
 
+        NoticeItem basicNotice,
         NoticeItem commonNotice,
         NoticeItem firstDepartmentNotice,
         NoticeItem secondDepartmentNotice,
 
+        List<AnswerItem> basicAnswers,
         List<AnswerItem> commonAnswers,
         List<AnswerItem> firstDepartmentAnswers,
         List<AnswerItem> secondDepartmentAnswers

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/entity/SectionType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/entity/SectionType.java
@@ -1,6 +1,7 @@
 package com.example.cowmjucraft.domain.recruit.entity;
 
 public enum SectionType {
+    BASIC,
     COMMON,
     DEPARTMENT
 }

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/exception/RecruitErrorType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/exception/RecruitErrorType.java
@@ -20,7 +20,7 @@ public enum RecruitErrorType implements ErrorCode {
     NOTICE_NOT_IN_THIS_FORM(400, "해당 폼에 속한 공지사항이 아닙니다."),
     SOURCE_FORM_ID_REQUIRED(400, "sourceFormId가 필요합니다."),
     SOURCE_AND_TARGET_CANNOT_BE_SAME(400, "sourceFormId와 targetFormId는 같을 수 없습니다."),
-    COMMON_SECTION_CANNOT_HAVE_DEPARTMENT(400, "공통 섹션에는 부서가 있을 수 없습니다."),
+    COMMON_SECTION_CANNOT_HAVE_DEPARTMENT(400, "기본/공통 섹션에는 부서가 있을 수 없습니다."),
     SELECT_OPTIONS_ONLY_FOR_SELECT(400, "선택형 문항에만 선택 옵션을 설정할 수 있습니다."),
     DEPARTMENT_TYPE_REQUIRED_FOR_DEPARTMENT_SECTION(400, "부서 섹션에는 부서 타입이 필요합니다."),
     APPLICATION_NOT_IN_THIS_FORM(400, "해당 폼에 속한 지원서가 아닙니다."),

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/admin/ApplicationAdminService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/admin/ApplicationAdminService.java
@@ -87,6 +87,7 @@ public class ApplicationAdminService {
                 application.getResultStatus(),
                 application.getCreatedAt(),
                 application.getUpdatedAt(),
+                groups.getBasic(),
                 groups.getCommon(),
                 groups.getFirstDepartment(),
                 groups.getSecondDepartment()

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/admin/FormAdminService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/admin/FormAdminService.java
@@ -99,9 +99,7 @@ public class FormAdminService {
             throw new RecruitException(RecruitErrorType.DUPLICATE_QUESTION_ORDER);
         }
 
-        if (request.getSectionType() == SectionType.COMMON && request.getDepartmentType() != null) {
-            throw new RecruitException(RecruitErrorType.COMMON_SECTION_CANNOT_HAVE_DEPARTMENT);
-        }
+        validateSectionDepartment(request.getSectionType(), request.getDepartmentType());
 
         if (request.getAnswerType() != AnswerType.SELECT && request.getSelectOptions() != null) {
             throw new RecruitException(RecruitErrorType.SELECT_OPTIONS_ONLY_FOR_SELECT);
@@ -211,9 +209,7 @@ public class FormAdminService {
             throw new RecruitException(RecruitErrorType.FORM_QUESTION_NOT_IN_THIS_FORM);
         }
 
-        if (request.getSectionType() == SectionType.COMMON && request.getDepartmentType() != null) {
-            throw new RecruitException(RecruitErrorType.COMMON_SECTION_CANNOT_HAVE_DEPARTMENT);
-        }
+        validateSectionDepartment(request.getSectionType(), request.getDepartmentType());
         if (request.getAnswerType() != AnswerType.SELECT && request.getSelectOptions() != null) {
             throw new RecruitException(RecruitErrorType.SELECT_OPTIONS_ONLY_FOR_SELECT);
         }
@@ -249,6 +245,7 @@ public class FormAdminService {
                 .orElseThrow(() -> new RecruitException(RecruitErrorType.SOURCE_FORM_NOT_FOUND));
 
         formQuestionRepository.deleteAllByForm(targetForm);
+        formNoticeRepository.deleteAllByForm(targetForm);
 
         List<FormQuestion> sourceQuestions =
                 formQuestionRepository.findAllByFormOrderByQuestionOrderAsc(sourceForm);
@@ -269,6 +266,19 @@ public class FormAdminService {
             formQuestionRepository.save(newFormQuestion);
 
             copied++;
+        }
+
+        List<FormNotice> sourceNotices = formNoticeRepository.findAllByForm(sourceForm);
+        for (FormNotice notice : sourceNotices) {
+            FormNotice newNotice = FormNotice.builder()
+                    .form(targetForm)
+                    .sectionType(notice.getSectionType())
+                    .departmentType(notice.getDepartmentType())
+                    .title(notice.getTitle())
+                    .content(notice.getContent())
+                    .build();
+
+            formNoticeRepository.save(newNotice);
         }
 
         return new FormCopyAdminResponse(targetFormId, sourceFormId, copied);
@@ -302,12 +312,7 @@ public class FormAdminService {
             throw new RecruitException(RecruitErrorType.NOTICE_NOT_IN_THIS_FORM);
         }
 
-        if (request.getSectionType() == SectionType.DEPARTMENT && request.getDepartmentType() == null) {
-            throw new RecruitException(RecruitErrorType.DEPARTMENT_TYPE_REQUIRED_FOR_DEPARTMENT_SECTION);
-        }
-        if (request.getSectionType() == SectionType.COMMON && request.getDepartmentType() != null) {
-            throw new RecruitException(RecruitErrorType.COMMON_SECTION_CANNOT_HAVE_DEPARTMENT);
-        }
+        validateNoticeRequest(request);
 
         notice.update(
                 request.getSectionType(),
@@ -330,10 +335,17 @@ public class FormAdminService {
     }
 
     private void validateNoticeRequest(FormNoticeRequest request) {
-        if (request.getSectionType() == SectionType.DEPARTMENT && request.getDepartmentType() == null) {
+        validateSectionDepartment(request.getSectionType(), request.getDepartmentType());
+    }
+
+    private void validateSectionDepartment(SectionType sectionType, DepartmentType departmentType) {
+        if (sectionType == null) {
+            throw new RecruitException(RecruitErrorType.INVALID_SECTION_OR_DEPARTMENT_TYPE);
+        }
+        if (sectionType == SectionType.DEPARTMENT && departmentType == null) {
             throw new RecruitException(RecruitErrorType.DEPARTMENT_TYPE_REQUIRED_FOR_DEPARTMENT_SECTION);
         }
-        if (request.getSectionType() == SectionType.COMMON && request.getDepartmentType() != null) {
+        if (sectionType != SectionType.DEPARTMENT && departmentType != null) {
             throw new RecruitException(RecruitErrorType.COMMON_SECTION_CANNOT_HAVE_DEPARTMENT);
         }
     }

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
@@ -56,15 +56,15 @@ public class ApplicationService {
         }
 
         Map<Long, FormQuestion> formQuestionMap = new HashMap<>();
-        Set<Long> requiredCommonIds = new HashSet<>();
+        Set<Long> requiredAlwaysIds = new HashSet<>();
         Set<Long> requiredDeptIds = new HashSet<>();
 
         for (FormQuestion formQuestion : formQuestions) {
             formQuestionMap.put(formQuestion.getId(), formQuestion);
 
             if (formQuestion.isRequired()) {
-                if (formQuestion.getSectionType() == SectionType.COMMON) {
-                    requiredCommonIds.add(formQuestion.getId());
+                if (isAlwaysVisibleSection(formQuestion.getSectionType())) {
+                    requiredAlwaysIds.add(formQuestion.getId());
                 } else if (formQuestion.getSectionType() == SectionType.DEPARTMENT) {
                     if (formQuestion.getDepartmentType() == firstDepartment || formQuestion.getDepartmentType() == secondDepartment) {
                         requiredDeptIds.add(formQuestion.getId());
@@ -99,7 +99,7 @@ public class ApplicationService {
             answerValueMap.put(formQuestionId, value);
         }
 
-        for (Long requiredId : requiredCommonIds) {
+        for (Long requiredId : requiredAlwaysIds) {
             String value = answerValueMap.get(requiredId);
             if (value == null) {
                 throw new RecruitException(RecruitErrorType.REQUIRED_ANSWER_MISSING);
@@ -183,6 +183,7 @@ public class ApplicationService {
 
         Map<String, String> urlMap = fileKeys.isEmpty() ? Map.of() : s3PresignFacade.presignGet(fileKeys);
 
+        List<ApplicationReadResponse.AnswerItem> basic = new ArrayList<>();
         List<ApplicationReadResponse.AnswerItem> common = new ArrayList<>();
         List<ApplicationReadResponse.AnswerItem> firstDepartment = new ArrayList<>();
         List<ApplicationReadResponse.AnswerItem> secondDepartment = new ArrayList<>();
@@ -193,6 +194,11 @@ public class ApplicationService {
 
             if (formQuestion.getAnswerType() == AnswerType.FILE && value != null) {
                 value = urlMap.getOrDefault(value, value);
+            }
+
+            if (formQuestion.getSectionType() == SectionType.BASIC) {
+                basic.add(new ApplicationReadResponse.AnswerItem(formQuestion.getId(), value));
+                continue;
             }
 
             if (formQuestion.getSectionType() == SectionType.COMMON) {
@@ -215,6 +221,7 @@ public class ApplicationService {
 
         List<FormNotice> notices = formNoticeRepository.findAllByForm(form);
 
+        ApplicationReadResponse.NoticeItem basicNotice = null;
         ApplicationReadResponse.NoticeItem commonNotice = null;
         ApplicationReadResponse.NoticeItem firstDepartmentNotice = null;
         ApplicationReadResponse.NoticeItem secondDepartmentNotice = null;
@@ -223,7 +230,9 @@ public class ApplicationService {
             ApplicationReadResponse.NoticeItem item =
                     new ApplicationReadResponse.NoticeItem(notice.getTitle(), notice.getContent());
 
-            if (notice.getSectionType() == SectionType.COMMON) {
+            if (notice.getSectionType() == SectionType.BASIC) {
+                basicNotice = item;
+            } else if (notice.getSectionType() == SectionType.COMMON) {
                 commonNotice = item;
             } else if (notice.getSectionType() == SectionType.DEPARTMENT) {
                 if (notice.getDepartmentType() == application.getFirstDepartment()) {
@@ -242,9 +251,11 @@ public class ApplicationService {
                 application.getSecondDepartment(),
                 application.getCreatedAt(),
                 application.getUpdatedAt(),
+                basicNotice,
                 commonNotice,
                 firstDepartmentNotice,
                 secondDepartmentNotice,
+                basic,
                 common,
                 firstDepartment,
                 secondDepartment
@@ -402,5 +413,9 @@ public class ApplicationService {
 
     public S3PresignFacade.PresignPutBatchResult createAnswerFilePresignPut(List<S3PresignFacade.PresignPutFile> files) {
         return s3PresignFacade.createPresignPutBatch("uploads/recruit/answers", files);
+    }
+
+    private boolean isAlwaysVisibleSection(SectionType sectionType) {
+        return sectionType == SectionType.BASIC || sectionType == SectionType.COMMON;
     }
 }


### PR DESCRIPTION
# 요약

지원서 폼에 Google Forms처럼 기본 정보 / 공통 질문 / 지원 부서별 질문을 나눌 수 있도록 백엔드 섹션 모델을 확장했습니다.

# 작업 내용

- [x] 모집 폼 섹션 타입에 `BASIC`을 추가했습니다.
- [x] 문항/안내문 생성 및 수정 시 섹션별 부서 설정 규칙을 검증하도록 정리했습니다.
  - `BASIC`, `COMMON`: `departmentType` 없음
  - `DEPARTMENT`: `departmentType` 필수
- [x] 지원서 제출 시 `BASIC` 문항을 공통 문항처럼 항상 노출/필수 검증 대상에 포함했습니다.
- [x] 지원서 조회 응답과 관리자 지원서 상세 응답에 `basicNotice`, `basicAnswers`를 추가했습니다.
- [x] 폼 복사 시 문항뿐 아니라 섹션 제목/설명에 해당하는 안내문도 함께 복사되도록 변경했습니다.
- [x] Swagger 설명에 `BASIC / COMMON / DEPARTMENT` 섹션 규칙을 반영했습니다.

# 검증

- [x] `./gradlew compileJava`
- [x] `./gradlew build -x test`
- [ ] `./gradlew test`

`./gradlew test`는 `CowMjuCraftApplicationTests.contextLoads()`에서 로컬 테스트 DB 설정이 없어 실패했습니다.

```text
Failed to configure a DataSource: 'url' attribute is not specified
Reason: Failed to determine a suitable driver class
```

# 기타 (논의하고 싶은 부분)

FE에서는 `sectionType=BASIC`을 기본 정보 섹션으로 렌더링하고, 지원서 조회/수정 화면에서는 `basicNotice`, `basicAnswers`를 별도 카드로 표시하면 됩니다.

# 타 직군 전달 사항

관리자 페이지에서 섹션 제목/설명은 기존 안내문 API를 사용하되, `sectionType`에 `BASIC`, `COMMON`, `DEPARTMENT`를 구분해서 저장하면 지원서 화면에 섹션별로 반영할 수 있습니다.

close #
