### PR TITLE
feat: 지원자 이름과 파일 링크 응답 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/AnswerGroupsAdmin.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/AnswerGroupsAdmin.java
@@ -13,7 +13,13 @@ public class AnswerGroupsAdmin {
     private final List<AnswerItem> firstDepartment;
     private final List<AnswerItem> secondDepartment;
 
-    public AnswerGroupsAdmin(Application application, List<Answer> answers, Map<String, String> urlMap) {
+    public AnswerGroupsAdmin(
+            Application application,
+            List<Answer> answers,
+            Map<String, String> previewUrlMap,
+            Map<String, String> downloadUrlMap,
+            Map<String, String> fileNameMap
+    ) {
         this.basic = new ArrayList<>();
         this.common = new ArrayList<>();
         this.firstDepartment = new ArrayList<>();
@@ -26,27 +32,33 @@ public class AnswerGroupsAdmin {
             FormQuestion formQuestion = answer.getFormQuestion();
             String key = answer.getValue();
             String fileUrl = null;
+            String previewUrl = null;
+            String downloadUrl = null;
+            String fileName = null;
 
             if (formQuestion.getAnswerType() == AnswerType.FILE && key != null) {
-                fileUrl = urlMap.get(key);
+                previewUrl = previewUrlMap.get(key);
+                downloadUrl = downloadUrlMap.get(key);
+                fileUrl = previewUrl;
+                fileName = fileNameMap.get(key);
             }
 
             if (formQuestion.getSectionType() == SectionType.BASIC) {
-                basic.add(new AnswerItem(formQuestion.getId(), answer.getValue(), fileUrl));
+                basic.add(new AnswerItem(formQuestion.getId(), answer.getValue(), fileUrl, previewUrl, downloadUrl, fileName));
                 continue;
             }
 
             if (formQuestion.getSectionType() == SectionType.COMMON) {
-                common.add(new AnswerItem(formQuestion.getId(), answer.getValue(), fileUrl));
+                common.add(new AnswerItem(formQuestion.getId(), answer.getValue(), fileUrl, previewUrl, downloadUrl, fileName));
                 continue;
             }
 
             if (formQuestion.getSectionType() == SectionType.DEPARTMENT) {
                 DepartmentType dt = formQuestion.getDepartmentType();
                 if (dt == first) {
-                    firstDepartment.add(new AnswerItem(formQuestion.getId(), answer.getValue(), fileUrl));
+                    firstDepartment.add(new AnswerItem(formQuestion.getId(), answer.getValue(), fileUrl, previewUrl, downloadUrl, fileName));
                 } else if (dt == second) {
-                    secondDepartment.add(new AnswerItem(formQuestion.getId(), answer.getValue(), fileUrl));
+                    secondDepartment.add(new AnswerItem(formQuestion.getId(), answer.getValue(), fileUrl, previewUrl, downloadUrl, fileName));
                 }
             }
         }

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/AnswerItem.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/AnswerItem.java
@@ -1,12 +1,33 @@
 package com.example.cowmjucraft.domain.recruit.dto.admin.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class AnswerItem {
     private Long formQuestionId;
     private String value;
     private String fileUrl;
+    private String previewUrl;
+    private String downloadUrl;
+    private String fileName;
+
+    public AnswerItem(Long formQuestionId, String value, String fileUrl) {
+        this(formQuestionId, value, fileUrl, fileUrl, null, null);
+    }
+
+    public AnswerItem(
+            Long formQuestionId,
+            String value,
+            String fileUrl,
+            String previewUrl,
+            String downloadUrl,
+            String fileName
+    ) {
+        this.formQuestionId = formQuestionId;
+        this.value = value;
+        this.fileUrl = fileUrl;
+        this.previewUrl = previewUrl;
+        this.downloadUrl = downloadUrl;
+        this.fileName = fileName;
+    }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/ApplicationDetailAdminResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/ApplicationDetailAdminResponse.java
@@ -15,6 +15,7 @@ public class ApplicationDetailAdminResponse {
     private Long applicationId;
 
     private String studentId;
+    private String applicantName;
 
     private DepartmentType firstDepartment;
     private DepartmentType secondDepartment;

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/ApplicationListAdminResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/admin/response/ApplicationListAdminResponse.java
@@ -13,6 +13,7 @@ public class ApplicationListAdminResponse {
     private Long applicationId;
 
     private String studentId;
+    private String applicantName;
 
     private DepartmentType firstDepartment;
     private DepartmentType secondDepartment;

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/repository/AnswerRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/repository/AnswerRepository.java
@@ -15,6 +15,9 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     @Query("select a from Answer a join fetch a.formQuestion where a.application = :application")
     List<Answer> findAllByApplicationFetchFormQuestion(@Param("application") Application application);
 
+    @Query("select a from Answer a join fetch a.formQuestion fq join fetch fq.question where a.application in :applications")
+    List<Answer> findAllByApplicationInFetchFormQuestion(@Param("applications") List<Application> applications);
+
     List<Answer> findAllByApplication(Application application);
 
     void deleteAllByApplication(Application application);

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/admin/ApplicationAdminService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/admin/ApplicationAdminService.java
@@ -16,13 +16,22 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class ApplicationAdminService {
+
+    private static final Set<String> APPLICANT_NAME_LABELS = Set.of("이름", "성명", "지원자 이름");
+    private static final Pattern UUID_FILE_PREFIX = Pattern.compile(
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-"
+    );
 
     private final FormRepository formRepository;
     private final ApplicationRepository applicationRepository;
@@ -35,12 +44,18 @@ public class ApplicationAdminService {
                 .orElseThrow(() -> new RecruitException(RecruitErrorType.FORM_NOT_FOUND));
 
         List<Application> apps = applicationRepository.findAllByForm(form);
+        List<Answer> answers = apps.isEmpty()
+                ? List.of()
+                : answerRepository.findAllByApplicationInFetchFormQuestion(apps);
+        Map<Long, String> applicantNames = extractApplicantNames(answers);
+
         List<ApplicationListAdminResponse> result = new ArrayList<>();
 
         for (Application application : apps) {
             result.add(new ApplicationListAdminResponse(
                     application.getId(),
                     application.getStudentId(),
+                    applicantNames.get(application.getId()),
                     application.getFirstDepartment(),
                     application.getSecondDepartment(),
                     application.getResultStatus(),
@@ -69,19 +84,19 @@ public class ApplicationAdminService {
         List<String> fileKeys = answers.stream().filter(answer -> answer.getFormQuestion().getAnswerType() == AnswerType.FILE)
                 .map(Answer::getValue).filter(Objects::nonNull).distinct().toList();
 
-        Map<String, String> urlMap;
-
-        if (fileKeys.isEmpty()) {
-            urlMap = Map.of();
-        } else {
-            urlMap = s3PresignFacade.presignGet(fileKeys);
-        }
-
-        AnswerGroupsAdmin groups = new AnswerGroupsAdmin(application, answers, urlMap);
+        FileLinkMaps fileLinkMaps = createFileLinkMaps(fileKeys);
+        AnswerGroupsAdmin groups = new AnswerGroupsAdmin(
+                application,
+                answers,
+                fileLinkMaps.previewUrlMap(),
+                fileLinkMaps.downloadUrlMap(),
+                fileLinkMaps.fileNameMap()
+        );
 
         return new ApplicationDetailAdminResponse(
                 application.getId(),
                 application.getStudentId(),
+                extractApplicantNames(answers).get(application.getId()),
                 application.getFirstDepartment(),
                 application.getSecondDepartment(),
                 application.getResultStatus(),
@@ -110,5 +125,85 @@ public class ApplicationAdminService {
                 .orElseThrow(() -> new RecruitException(RecruitErrorType.APPLICATION_NOT_FOUND));
 
         application.setResultStatus(request.getResultStatus());
+    }
+
+    private Map<Long, String> extractApplicantNames(List<Answer> answers) {
+        return answers.stream()
+                .filter(answer -> isApplicantNameQuestion(answer.getFormQuestion()))
+                .filter(answer -> answer.getValue() != null && !answer.getValue().isBlank())
+                .collect(Collectors.toMap(
+                        answer -> answer.getApplication().getId(),
+                        answer -> answer.getValue().trim(),
+                        (first, ignored) -> first
+                ));
+    }
+
+    private boolean isApplicantNameQuestion(FormQuestion formQuestion) {
+        if (formQuestion == null || formQuestion.getQuestion() == null) {
+            return false;
+        }
+        String label = normalizeQuestionLabel(formQuestion.getQuestion().getLabel());
+        return APPLICANT_NAME_LABELS.contains(label);
+    }
+
+    private String normalizeQuestionLabel(String label) {
+        if (label == null) {
+            return "";
+        }
+        return label.trim().replace("*", "").trim();
+    }
+
+    private FileLinkMaps createFileLinkMaps(List<String> fileKeys) {
+        if (fileKeys.isEmpty()) {
+            return new FileLinkMaps(Map.of(), Map.of(), Map.of());
+        }
+
+        Map<String, String> previewUrlMap = new HashMap<>();
+        Map<String, String> downloadUrlMap = new HashMap<>();
+        Map<String, String> fileNameMap = new HashMap<>();
+
+        for (String key : fileKeys) {
+            String fileName = extractOriginalFileName(key);
+            String contentType = inferContentType(fileName);
+
+            previewUrlMap.put(key, s3PresignFacade.presignGet(key, fileName, contentType, false));
+            downloadUrlMap.put(key, s3PresignFacade.presignGet(key, fileName, contentType, true));
+            fileNameMap.put(key, fileName);
+        }
+
+        return new FileLinkMaps(previewUrlMap, downloadUrlMap, fileNameMap);
+    }
+
+    private String extractOriginalFileName(String key) {
+        String trimmed = key == null ? "" : key.trim();
+        int lastSlash = trimmed.lastIndexOf('/');
+        String fileName = lastSlash >= 0 ? trimmed.substring(lastSlash + 1) : trimmed;
+        String withoutUuid = UUID_FILE_PREFIX.matcher(fileName).replaceFirst("");
+        return withoutUuid.isBlank() ? "download" : withoutUuid;
+    }
+
+    private String inferContentType(String fileName) {
+        String lower = fileName == null ? "" : fileName.toLowerCase();
+        if (lower.endsWith(".pdf")) return "application/pdf";
+        if (lower.endsWith(".png")) return "image/png";
+        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+        if (lower.endsWith(".webp")) return "image/webp";
+        if (lower.endsWith(".gif")) return "image/gif";
+        if (lower.endsWith(".txt")) return "text/plain";
+        if (lower.endsWith(".doc")) return "application/msword";
+        if (lower.endsWith(".docx")) return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+        if (lower.endsWith(".ppt")) return "application/vnd.ms-powerpoint";
+        if (lower.endsWith(".pptx")) return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+        if (lower.endsWith(".xls")) return "application/vnd.ms-excel";
+        if (lower.endsWith(".xlsx")) return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+        if (lower.endsWith(".zip")) return "application/zip";
+        return "application/octet-stream";
+    }
+
+    private record FileLinkMaps(
+            Map<String, String> previewUrlMap,
+            Map<String, String> downloadUrlMap,
+            Map<String, String> fileNameMap
+    ) {
     }
 }


### PR DESCRIPTION
# 요약

관리자 지원자 목록/상세 화면에서 지원자 이름과 첨부 파일 링크를 더 자연스럽게 사용할 수 있도록 모집 지원서 관리자 응답을 확장했습니다.

# 작업 내용

- [x] 관리자 지원자 목록 응답에 `applicantName`을 추가했습니다.
- [x] 관리자 지원자 상세 응답에 `applicantName`을 추가했습니다.
- [x] 이름은 지원서 답변 중 `이름`, `성명`, `지원자 이름` 문항 값을 기준으로 추출합니다.
- [x] 파일 답변 응답에 `previewUrl`, `downloadUrl`, `fileName`을 추가했습니다.
- [x] 기존 프론트 호환을 위해 `fileUrl`은 유지하고, 미리보기 URL과 동일하게 내려줍니다.
- [x] 파일명은 S3 key의 UUID prefix를 제거한 원본 파일명 형태로 내려줍니다.
- [x] 지원자 목록에서 이름 추출 시 답변과 질문을 한 번에 fetch 하도록 Repository 조회를 추가했습니다.

# 검증

- [x] `./gradlew compileJava`
- [x] `./gradlew build -x test`

# 참고

- 이 변경은 기존 응답 필드를 제거하지 않고 필드만 추가하므로 기존 클라이언트와 호환됩니다.
- FE에서는 `applicantName`을 목록의 대표 텍스트로 사용하고, 파일 답변에서 `previewUrl`과 `downloadUrl`을 각각 미리보기/다운로드 버튼에 연결하면 됩니다.

close #
