### PR TITLE
fix: 지원서 조회 응답 및 회차 조회 개선

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/request/ApplicationReadRequest.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/request/ApplicationReadRequest.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ApplicationReadRequest {
+    private Long formId;
     private String studentId;
     private String password;
 }

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/request/ApplicationUpdateRequest.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/request/ApplicationUpdateRequest.java
@@ -10,6 +10,7 @@ import java.util.List;
 @NoArgsConstructor
 public class ApplicationUpdateRequest {
 
+    private Long formId;
     private String studentId;
     private String password;
 

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/request/ResultReadRequest.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/request/ResultReadRequest.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ResultReadRequest {
+    private Long formId;
     private String studentId;
     private String password;
 }

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/response/ApplicationReadResponse.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/dto/client/response/ApplicationReadResponse.java
@@ -25,13 +25,24 @@ public record ApplicationReadResponse(
         List<AnswerItem> basicAnswers,
         List<AnswerItem> commonAnswers,
         List<AnswerItem> firstDepartmentAnswers,
-        List<AnswerItem> secondDepartmentAnswers
+        List<AnswerItem> secondDepartmentAnswers,
+
+        List<ApplicationFormInfoResponse.NoticeDto> notices,
+        List<ApplicationFormInfoResponse.QuestionDto> questions
 
 ) {
     public record AnswerItem(
             Long formQuestionId,
-            String value
-    ) {}
+            String value,
+            String fileKey,
+            String fileUrl,
+            String fileName
+    ) {
+        public AnswerItem(Long formQuestionId, String value) {
+            this(formQuestionId, value, null, null, null);
+        }
+    }
+
     public record NoticeItem(
             String title,
             String content

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
@@ -156,13 +156,7 @@ public class ApplicationService {
     @Transactional(readOnly = true)
     public ApplicationReadResponse read(ApplicationReadRequest request) {
 
-        Form form = formRepository.findFirstByOpenTrue();
-        if (form == null) {
-            form = formRepository.findTopByOrderByIdDesc();
-        }
-        if (form == null) {
-            throw new RecruitException(RecruitErrorType.FORM_NOT_FOUND);
-        }
+        Form form = findReadableForm(request.getFormId());
 
         Application application = applicationRepository.findByFormAndStudentId(form, request.getStudentId())
                 .orElseThrow(() -> new RecruitException(RecruitErrorType.APPLICATION_NOT_FOUND));
@@ -192,17 +186,13 @@ public class ApplicationService {
             FormQuestion formQuestion = answer.getFormQuestion();
             String value = answer.getValue();
 
-            if (formQuestion.getAnswerType() == AnswerType.FILE && value != null) {
-                value = urlMap.getOrDefault(value, value);
-            }
-
             if (formQuestion.getSectionType() == SectionType.BASIC) {
-                basic.add(new ApplicationReadResponse.AnswerItem(formQuestion.getId(), value));
+                basic.add(toAnswerItem(formQuestion, value, urlMap));
                 continue;
             }
 
             if (formQuestion.getSectionType() == SectionType.COMMON) {
-                common.add(new ApplicationReadResponse.AnswerItem(formQuestion.getId(), value));
+                common.add(toAnswerItem(formQuestion, value, urlMap));
                 continue;
             }
 
@@ -210,9 +200,9 @@ public class ApplicationService {
                 DepartmentType departmentType = formQuestion.getDepartmentType();
 
                 if (departmentType == application.getFirstDepartment()) {
-                    firstDepartment.add(new ApplicationReadResponse.AnswerItem(formQuestion.getId(), value));
+                    firstDepartment.add(toAnswerItem(formQuestion, value, urlMap));
                 } else if (departmentType == application.getSecondDepartment()) {
-                    secondDepartment.add(new ApplicationReadResponse.AnswerItem(formQuestion.getId(), value));
+                    secondDepartment.add(toAnswerItem(formQuestion, value, urlMap));
                 } else {
                     throw new RecruitException(RecruitErrorType.INVALID_SECTION_OR_DEPARTMENT_TYPE);
                 }
@@ -220,6 +210,7 @@ public class ApplicationService {
         }
 
         List<FormNotice> notices = formNoticeRepository.findAllByForm(form);
+        List<FormQuestion> formQuestions = formQuestionRepository.findAllByFormOrderByQuestionOrderAsc(form);
 
         ApplicationReadResponse.NoticeItem basicNotice = null;
         ApplicationReadResponse.NoticeItem commonNotice = null;
@@ -258,17 +249,16 @@ public class ApplicationService {
                 basic,
                 common,
                 firstDepartment,
-                secondDepartment
+                secondDepartment,
+                notices.stream().map(ApplicationFormInfoResponse.NoticeDto::from).toList(),
+                formQuestions.stream().map(ApplicationFormInfoResponse.QuestionDto::from).toList()
         );
     }
 
     @Transactional
     public ApplicationUpdateResponse update(ApplicationUpdateRequest request) {
 
-        Form form = formRepository.findFirstByOpenTrue();
-        if (form == null || !form.isOpen()) {
-            throw new RecruitException(RecruitErrorType.RECRUITMENT_CLOSED);
-        }
+        Form form = findWritableForm(request.getFormId());
 
         Application application = applicationRepository.findByFormAndStudentId(form, request.getStudentId())
                 .orElseThrow(() -> new RecruitException(RecruitErrorType.APPLICATION_NOT_FOUND));
@@ -347,6 +337,9 @@ public class ApplicationService {
                 }
 
                 Answer existing = answerMap.get(formQuestion.getId());
+                if (formQuestion.getAnswerType() == AnswerType.FILE && value != null && isHttpUrl(value) && existing != null) {
+                    value = existing.getValue();
+                }
 
                 if (value == null) {
                     if (formQuestion.isRequired()) {
@@ -378,13 +371,7 @@ public class ApplicationService {
     @Transactional(readOnly = true)
     public ResultReadResponse readResult(ResultReadRequest request) {
 
-        Form form = formRepository.findFirstByOpenTrue();
-        if (form == null) {
-            form = formRepository.findTopByOrderByIdDesc();
-        }
-        if (form == null) {
-            throw new RecruitException(RecruitErrorType.FORM_NOT_FOUND);
-        }
+        Form form = findReadableForm(request.getFormId());
 
         Application application = applicationRepository.findByFormAndStudentId(form, request.getStudentId())
                 .orElseThrow(() -> new RecruitException(RecruitErrorType.APPLICATION_NOT_FOUND));
@@ -417,5 +404,63 @@ public class ApplicationService {
 
     private boolean isAlwaysVisibleSection(SectionType sectionType) {
         return sectionType == SectionType.BASIC || sectionType == SectionType.COMMON;
+    }
+
+    private Form findReadableForm(Long formId) {
+        if (formId != null) {
+            return formRepository.findById(formId)
+                    .orElseThrow(() -> new RecruitException(RecruitErrorType.FORM_NOT_FOUND));
+        }
+
+        Form form = formRepository.findFirstByOpenTrue();
+        if (form == null) {
+            form = formRepository.findTopByOrderByIdDesc();
+        }
+        if (form == null) {
+            throw new RecruitException(RecruitErrorType.FORM_NOT_FOUND);
+        }
+        return form;
+    }
+
+    private Form findWritableForm(Long formId) {
+        Form form = formId != null
+                ? formRepository.findById(formId)
+                .orElseThrow(() -> new RecruitException(RecruitErrorType.FORM_NOT_FOUND))
+                : formRepository.findFirstByOpenTrue();
+
+        if (form == null || !form.isOpen()) {
+            throw new RecruitException(RecruitErrorType.RECRUITMENT_CLOSED);
+        }
+        return form;
+    }
+
+    private ApplicationReadResponse.AnswerItem toAnswerItem(
+            FormQuestion formQuestion,
+            String value,
+            Map<String, String> fileUrlMap
+    ) {
+        if (formQuestion.getAnswerType() != AnswerType.FILE || value == null) {
+            return new ApplicationReadResponse.AnswerItem(formQuestion.getId(), value);
+        }
+
+        return new ApplicationReadResponse.AnswerItem(
+                formQuestion.getId(),
+                value,
+                value,
+                fileUrlMap.getOrDefault(value, value),
+                extractOriginalFileName(value)
+        );
+    }
+
+    private String extractOriginalFileName(String key) {
+        String trimmed = key == null ? "" : key.trim();
+        int lastSlash = trimmed.lastIndexOf('/');
+        String fileName = lastSlash >= 0 ? trimmed.substring(lastSlash + 1) : trimmed;
+        return fileName.replaceFirst("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-", "");
+    }
+
+    private boolean isHttpUrl(String value) {
+        String trimmed = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        return trimmed.startsWith("http://") || trimmed.startsWith("https://");
     }
 }


### PR DESCRIPTION
# 요약

지원서 조회/수정/결과 조회 흐름에서 파일 답변과 모집 회차 조회가 안전하게 동작하도록 백엔드 응답과 조회 기준을 정리했습니다.

# 작업 내용

- [x] 지원서 조회 응답에서 파일 답변의 원본 key와 presigned URL, 파일명을 분리해 제공합니다.
- [x] 파일 답변 수정 시 presigned URL이 다시 저장되지 않도록 기존 파일 key를 유지합니다.
- [x] 지원서 조회/수정/결과 조회 요청에 선택적 `formId`를 추가해 특정 모집 회차 기준 조회를 지원합니다.
- [x] 지원서 조회 응답에 폼 질문/안내문 정보를 포함해 과거 모집 회차 조회 화면에서도 해당 폼 구성을 사용할 수 있게 했습니다.

# 기타 (논의하고 싶은 부분)

- `formId`가 없는 기존 요청은 현재 열린 폼, 없으면 최신 폼 기준으로 동작하도록 기존 호환성을 유지했습니다.
- 닫힌 폼에 대한 수정은 기존 모집 마감 정책에 따라 차단됩니다.

# 타 직군 전달 사항

- FE에서 `/apply/manage?formId={formId}`, `/apply/result?formId={formId}` 형태로 특정 모집 회차 조회가 가능합니다.

close #
