### PR TITLE
fix: 선택 해제된 모집 부서 답변 정리

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
@@ -324,25 +324,20 @@ public class ApplicationService {
                     throw new RecruitException(RecruitErrorType.FORM_QUESTION_NOT_FOUND);
                 }
 
-                if (formQuestion.getSectionType() == SectionType.DEPARTMENT) {
-                    DepartmentType dt = formQuestion.getDepartmentType();
-                    if (dt != currentFirst && dt != currentSecond) {
-                        throw new RecruitException(RecruitErrorType.ANSWER_FOR_UNSELECTED_DEPARTMENT);
-                    }
-                }
-
                 String value = a.getValue();
                 if (value != null && value.isBlank()) {
                     value = null;
                 }
 
                 Answer existing = answerMap.get(formQuestion.getId());
-                if (formQuestion.getAnswerType() == AnswerType.FILE && value != null && isHttpUrl(value) && existing != null) {
-                    value = existing.getValue();
+                boolean selectedDepartmentQuestion = true;
+                if (formQuestion.getSectionType() == SectionType.DEPARTMENT) {
+                    DepartmentType dt = formQuestion.getDepartmentType();
+                    selectedDepartmentQuestion = dt == currentFirst || dt == currentSecond;
                 }
 
                 if (value == null) {
-                    if (formQuestion.isRequired()) {
+                    if (formQuestion.isRequired() && selectedDepartmentQuestion) {
                         throw new RecruitException(RecruitErrorType.REQUIRED_ANSWER_CANNOT_BE_DELETED);
                     }
                     if (existing != null) {
@@ -352,6 +347,14 @@ public class ApplicationService {
                         answerRepository.delete(existing);
                     }
                     continue;
+                }
+
+                if (!selectedDepartmentQuestion) {
+                    throw new RecruitException(RecruitErrorType.ANSWER_FOR_UNSELECTED_DEPARTMENT);
+                }
+
+                if (formQuestion.getAnswerType() == AnswerType.FILE && isHttpUrl(value) && existing != null) {
+                    value = existing.getValue();
                 }
 
                 if (existing != null) {


### PR DESCRIPTION
## 요약
- 지원서 수정 시 선택 해제된 부서 질문의 null 삭제 요청을 허용합니다.
- 선택하지 않은 부서에 실제 값이 들어오는 경우에는 기존처럼 차단합니다.

## 검증
- ./gradlew compileJava