### PR TITLE
feat: MinIO 스토리지 설정 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/global/cloud/S3Config.java
+++ b/src/main/java/com/example/cowmjucraft/global/cloud/S3Config.java
@@ -1,10 +1,12 @@
 package com.example.cowmjucraft.global.cloud;
 
+import java.net.URI;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -13,10 +15,15 @@ public class S3Config {
     @Value("${aws.region}")
     private String region;
 
+    @Value("${aws.s3.endpoint}")
+    private String endpoint;
+
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.of(region))
+                .endpointOverride(URI.create(endpoint))
+                .serviceConfiguration(s3Configuration())
                 .build();
     }
 
@@ -24,6 +31,14 @@ public class S3Config {
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
                 .region(Region.of(region))
+                .endpointOverride(URI.create(endpoint))
+                .serviceConfiguration(s3Configuration())
+                .build();
+    }
+
+    private S3Configuration s3Configuration() {
+        return S3Configuration.builder()
+                .pathStyleAccessEnabled(true)
                 .build();
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,6 +26,10 @@ spring:
           starttls:
             enable: true
 
+aws:
+  s3:
+    endpoint: ${AWS_S3_ENDPOINT:http://localhost:9000}
+
 app:
   public-base-url: ${APP_PUBLIC_BASE_URL}
   order-view-path: ${APP_ORDER_VIEW_PATH}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,6 +25,10 @@ spring:
           starttls:
             enable: true
 
+aws:
+  s3:
+    endpoint: ${AWS_S3_ENDPOINT}
+
 app:
   public-base-url: ${APP_PUBLIC_BASE_URL}
   order-view-path: ${APP_ORDER_VIEW_PATH}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ server:
 aws:
   region: ${AWS_REGION:ap-northeast-2}
   s3:
+    endpoint: ${AWS_S3_ENDPOINT}
     bucket: ${AWS_S3_BUCKET}
 
 oauth:


### PR DESCRIPTION
# 요약

AWS SDK 기반 S3 클라이언트가 로컬과 운영 환경의 MinIO endpoint를 사용하도록 설정을 추가했습니다.

# 작업 내용

- [x] `S3Client`와 `S3Presigner`에 공통 endpoint override를 적용했습니다.
- [x] MinIO 호환을 위해 두 클라이언트에 path-style access를 적용했습니다.
- [x] 공통 S3 endpoint 설정을 `AWS_S3_ENDPOINT` 환경변수와 연결했습니다.
- [x] local 프로필은 endpoint 미지정 시 `http://localhost:9000`을 사용하도록 설정했습니다.
- [x] prod 프로필은 `AWS_S3_ENDPOINT`를 필수로 사용하도록 설정했습니다.
- [x] `./gradlew compileJava`로 컴파일을 검증했습니다.

# 기타 (논의하고 싶은 부분)

- 운영 환경에 `AWS_S3_ENDPOINT` 환경변수를 새로 설정해야 합니다.
- endpoint override와 path-style access는 presigned URL 생성에도 동일하게 적용됩니다.
- API 및 DB 스키마 변경은 없습니다.
- `SecurityConfig`, `JwtAuthenticationFilter`, `JwtTokenProvider` 변경은 없습니다.

# 타 직군 전달 사항

- 인프라에서는 운영 MinIO의 외부 접근 가능한 endpoint를 `AWS_S3_ENDPOINT`로 설정해 주세요.
- 브라우저가 presigned URL에 접근하므로 MinIO bucket의 CORS와 네트워크 접근 경로를 확인해야 합니다.
- 프론트엔드 API 스펙 변경은 없습니다.

close #이슈번호
