### PR TITLE
feat: MinIO Presigned URL 외부 endpoint 적용

### DIFF
--- a/src/main/java/com/example/cowmjucraft/global/cloud/S3Config.java
+++ b/src/main/java/com/example/cowmjucraft/global/cloud/S3Config.java
@@ -18,6 +18,9 @@ public class S3Config {
     @Value("${aws.s3.endpoint}")
     private String endpoint;
 
+    @Value("${aws.s3.public-endpoint}")
+    private String publicEndpoint;
+
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
@@ -31,7 +34,7 @@ public class S3Config {
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
                 .region(Region.of(region))
-                .endpointOverride(URI.create(endpoint))
+                .endpointOverride(URI.create(publicEndpoint))
                 .serviceConfiguration(s3Configuration())
                 .build();
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,6 +29,7 @@ spring:
 aws:
   s3:
     endpoint: ${AWS_S3_ENDPOINT:http://localhost:9000}
+    public-endpoint: ${AWS_S3_PUBLIC_ENDPOINT:http://localhost:9000}
 
 app:
   public-base-url: ${APP_PUBLIC_BASE_URL}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,6 +28,7 @@ spring:
 aws:
   s3:
     endpoint: ${AWS_S3_ENDPOINT}
+    public-endpoint: ${AWS_S3_PUBLIC_ENDPOINT}
 
 app:
   public-base-url: ${APP_PUBLIC_BASE_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ aws:
   region: ${AWS_REGION:ap-northeast-2}
   s3:
     endpoint: ${AWS_S3_ENDPOINT}
+    public-endpoint: ${AWS_S3_PUBLIC_ENDPOINT}
     bucket: ${AWS_S3_BUCKET}
 
 oauth:


### PR DESCRIPTION
# 요약

MinIO 내부 통신 endpoint와 외부 Presigned URL endpoint를 분리해 브라우저가 공개 도메인으로 파일에 접근할 수 있도록 수정했습니다.

# 작업 내용

- [x] `aws.s3.public-endpoint` 설정을 추가했습니다.
- [x] `S3Client`는 내부 통신용 `aws.s3.endpoint`를 계속 사용하도록 유지했습니다.
- [x] `S3Presigner`는 외부 접근용 `aws.s3.public-endpoint`로 URL을 생성하도록 변경했습니다.
- [x] local 프로필에서 내부·외부 endpoint의 기본값을 모두 `http://localhost:9000`으로 설정했습니다.
- [x] prod 프로필에서 `AWS_S3_PUBLIC_ENDPOINT` 환경변수를 사용하도록 설정했습니다.
- [x] 두 클라이언트의 path-style access 설정을 유지했습니다.
- [x] `./gradlew compileJava`로 컴파일을 검증했습니다.

# 기타 (논의하고 싶은 부분)

- 운영 환경에 `AWS_S3_PUBLIC_ENDPOINT` 환경변수를 추가해야 합니다.
- `AWS_S3_ENDPOINT`는 백엔드에서 MinIO로 접근할 내부 주소이고, `AWS_S3_PUBLIC_ENDPOINT`는 클라이언트가 접근할 공개 주소입니다.
- API 및 DB 스키마 변경은 없습니다.
- `SecurityConfig`, `JwtAuthenticationFilter`, `JwtTokenProvider` 변경은 없습니다.

# 타 직군 전달 사항

- 인프라에서는 `AWS_S3_PUBLIC_ENDPOINT`에 외부 접근 가능한 MinIO API 도메인을 설정해 주세요. 예: `https://minio-api.mju-craft.shop`
- 공개 도메인의 TLS, reverse proxy, MinIO bucket CORS 설정을 확인해야 합니다.
- 프론트엔드 API 스펙 변경은 없습니다.

close #이슈번호
