### PR TITLE
chore: 개발용 CORS 임시 전체 허용

### DIFF
--- a/src/main/java/com/example/cowmjucraft/global/config/CorsConfig.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/CorsConfig.java
@@ -15,15 +15,7 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOriginPatterns(List.of(
-                "https://mju-craft.shop",
-                "https://api.mju-craft.shop",
-                "http://localhost:5173",
-                "http://localhost:5174",
-                "https://*.s3.ap-northeast-2.amazonaws.com",
-                "https://*.s3.amazonaws.com",
-                "https://*.cloudfront.net"
-        ));
+        config.setAllowedOriginPatterns(List.of("*"));
 
         config.setAllowedMethods(List.of(
                 "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"


### PR DESCRIPTION
# 요약

MinIO 마이그레이션 개발·검증 기간 동안 다양한 로컬 및 임시 도메인에서 API를 호출할 수 있도록 CORS origin 제한을 임시 해제했습니다.

# 작업 내용

- [x] 허용 origin 목록을 `allowedOriginPatterns("*")`로 변경했습니다.
- [x] 기존 HTTP method, header, credentials, exposed header 설정은 유지했습니다.
- [x] `./gradlew compileJava`로 컴파일을 검증했습니다.

# 기타 (논의하고 싶은 부분)

- 개발 편의를 위한 임시 보안 완화이며 운영 도메인이 확정되면 명시적인 origin allowlist로 복구해야 합니다.
- `allowCredentials(true)` 상태에서 모든 origin pattern을 허용하므로 운영 장기 사용에는 적합하지 않습니다.
- API 및 DB 스키마 변경은 없습니다.
- `SecurityConfig`, `JwtAuthenticationFilter`, `JwtTokenProvider`는 수정하지 않았습니다.

# 타 직군 전달 사항

- 개발 중에는 별도 origin 등록 없이 백엔드 API를 호출할 수 있습니다.
- 운영 도메인 확정 후 허용할 프론트엔드·관리자 도메인 목록을 백엔드에 전달해 주세요.
- MinIO bucket CORS는 Spring API CORS와 별도이므로 필요 시 MinIO에서도 구성해야 합니다.

close #이슈번호
