### PR TITLE
chore: CORS 허용 도메인 제한

### DIFF
--- a/src/main/java/com/example/cowmjucraft/global/config/CorsConfig.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/CorsConfig.java
@@ -15,7 +15,12 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedOriginPatterns(List.of(
+                "https://mju-craft.shop",
+                "https://www.mju-craft.shop",
+                "http://localhost:5173",
+                "http://localhost:5174"
+        ));
 
         config.setAllowedMethods(List.of(
                 "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"
@@ -23,8 +28,6 @@ public class CorsConfig {
 
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of(
-                "Authorization",
-                "Set-Cookie",
                 "ETag",
                 "Content-Disposition",
                 "Location"


### PR DESCRIPTION
# 요약

개발 기간 동안 임시로 전체 허용했던 CORS origin을 운영 및 로컬 프론트엔드 도메인으로 제한했습니다.

# 작업 내용

- [x] 전체 origin 허용 패턴(`*`)을 제거했습니다.
- [x] 운영 도메인 `https://mju-craft.shop`, `https://www.mju-craft.shop`을 허용했습니다.
- [x] 로컬 개발 주소 `http://localhost:5173`, `http://localhost:5174`를 허용했습니다.
- [x] 파일 응답에 필요한 `ETag`, `Content-Disposition`, `Location` exposed header를 유지했습니다.
- [x] JavaScript에서 직접 읽을 수 없거나 불필요한 `Authorization`, `Set-Cookie` exposed header를 제거했습니다.
- [x] `./gradlew compileJava`로 컴파일을 검증했습니다.

# 기타 (논의하고 싶은 부분)

- credentials 허용과 HTTP method·request header 설정은 기존 동작을 유지합니다.
- API 및 DB 스키마 변경은 없습니다.
- `SecurityConfig`, `JwtAuthenticationFilter`, `JwtTokenProvider`는 수정하지 않았습니다.
- MinIO bucket CORS는 Spring API CORS와 별도 설정입니다.

# 타 직군 전달 사항

- 프론트엔드는 등록된 운영 도메인 또는 localhost 5173·5174 포트에서 백엔드 API를 호출해야 합니다.
- 추가 배포·미리보기 도메인이 생기면 별도 origin 등록이 필요합니다.
- 프론트엔드 API 스펙 변경은 없습니다.

close #이슈번호
