### PR TITLE
chore: CI/CD GitHub Actions 워크플로우 구성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches-ignore: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests
+        run: ./gradlew test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy to EC2 (SSM + Docker)
+name: Build & Push to Docker Hub
 
 on:
   push:
@@ -9,17 +9,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build-and-push:
     runs-on: ubuntu-latest
 
     env:
-      APP_NAME: cowmjucraft
       IMAGE: yunjin1213/cowmjucraft
-      TAG_LATEST: latest
-      ENV_DIR: /opt/cowmjucraft
-      ENV_FILE: /opt/cowmjucraft/prod.env
-      HOST_PORT: "8080"
-      CONTAINER_PORT: "8080"
 
     steps:
       - uses: actions/checkout@v4
@@ -36,101 +30,10 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ env.IMAGE }}:${{ env.TAG_LATEST }}
+            ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}
 
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Deploy on EC2 via SSM (create env safely)
-        shell: bash
+      - name: Trigger Coolify deploy
         run: |
-          set -euo pipefail
-
-          COMMAND_ID=$(aws ssm send-command \
-            --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
-            --document-name "AWS-RunShellScript" \
-            --comment "Deploy ${{ env.APP_NAME }} from GitHub Actions" \
-            --parameters commands='[
-              "set -e",
-              "sudo mkdir -p /opt/cowmjucraft",
-              "sudo tee /opt/cowmjucraft/prod.env > /dev/null << '\''EOF'\''",
-              "SPRING_PROFILES_ACTIVE=prod",
-              "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}",
-              "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}",
-              "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}",
-              "ADMIN_LOGIN_ID=${{ secrets.ADMIN_LOGIN_ID }}",
-              "ADMIN_PASSWORD=${{ secrets.ADMIN_PASSWORD }}",
-              "ADMIN_EMAIL=${{ secrets.ADMIN_EMAIL }}",
-              "JWT_SECRET=${{ secrets.JWT_SECRET }}",
-              "JWT_ACCESS_EXPIRATION_SECONDS=${{ secrets.JWT_ACCESS_EXPIRATION_SECONDS }}",
-              "JWT_REFRESH_EXPIRATION_SECONDS=${{ secrets.JWT_REFRESH_EXPIRATION_SECONDS }}",
-              "AWS_REGION=${{ secrets.AWS_REGION }}",
-              "AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }}",
-              "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}",
-              "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-
-              "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}",
-              "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}",
-              "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}",
-              "NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }}",
-              "NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }}",
-              "NAVER_REDIRECT_URI=${{ secrets.NAVER_REDIRECT_URI }}",
-
-              "MAIL_HOST=${{ secrets.MAIL_HOST }}",
-              "MAIL_PORT=${{ secrets.MAIL_PORT }}",
-              "MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}",
-              "MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}",
-              "MAIL_FROM=${{ secrets.MAIL_FROM }}",
-              "MAIL_FROM_NAME=${{ secrets.MAIL_FROM_NAME }}",
-              "APP_PUBLIC_BASE_URL=${{ secrets.APP_PUBLIC_BASE_URL }}",
-              "APP_ORDER_VIEW_PATH=${{ secrets.APP_ORDER_VIEW_PATH }}",
-              "APP_ORDER_VIEW_TOKEN_TTL_MINUTES=${{ secrets.APP_ORDER_VIEW_TOKEN_TTL_MINUTES }}",
-
-              "EOF",
-              "sudo chmod 600 /opt/cowmjucraft/prod.env",
-              "sudo docker pull yunjin1213/cowmjucraft:latest",
-              "sudo docker stop cowmjucraft || true",
-              "sudo docker rm cowmjucraft || true",
-              "sudo docker run -d --name cowmjucraft --restart always -p 8080:8080 --env-file /opt/cowmjucraft/prod.env yunjin1213/cowmjucraft:latest",
-              "sudo docker ps --filter name=cowmjucraft",
-              "sudo egrep -c '\''^JWT_SECRET='\'' /opt/cowmjucraft/prod.env | grep -q '\''^1$'\'' && echo '\''[OK] JWT_SECRET present'\'' || { echo '\''[FAIL] JWT_SECRET missing'\''; exit 1; }",
-              "sudo egrep -c '\''^JWT_ACCESS_EXPIRATION_SECONDS='\'' /opt/cowmjucraft/prod.env | grep -q '\''^1$'\'' && echo '\''[OK] JWT_ACCESS_EXPIRATION_SECONDS present'\'' || { echo '\''[FAIL] JWT_ACCESS_EXPIRATION_SECONDS missing'\''; exit 1; }",
-              "sudo egrep -c '\''^JWT_REFRESH_EXPIRATION_SECONDS='\'' /opt/cowmjucraft/prod.env | grep -q '\''^1$'\'' && echo '\''[OK] JWT_REFRESH_EXPIRATION_SECONDS present'\'' || { echo '\''[FAIL] JWT_REFRESH_EXPIRATION_SECONDS missing'\''; exit 1; }",
-              "sudo egrep -n '\''^(MAIL_|APP_)'\'' /opt/cowmjucraft/prod.env || true"
-            ]' \
-            --query "Command.CommandId" \
-            --output text)
-
-          echo "SSM CommandId: $COMMAND_ID"
-
-          for i in {1..60}; do
-            STATUS=$(aws ssm get-command-invocation \
-              --command-id "$COMMAND_ID" \
-              --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
-              --query "Status" \
-              --output text 2>/dev/null || echo "Pending")
-
-            echo "SSM command status ($i/60): $STATUS"
-
-            case "$STATUS" in
-              Success)
-                break
-                ;;
-              Failed|Cancelled|TimedOut|Cancelling)
-                break
-                ;;
-            esac
-
-            sleep 10
-          done
-
-          aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" \
-            --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
-            --output text
-
-          test "$STATUS" = "Success"
+          curl -fSs -X GET "${{ secrets.COOLIFY_WEBHOOK_URL }}" \
+            -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}"

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.withType(Test) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,62 @@
+# CI/테스트 환경용 설정 — MySQL·AWS·외부 서비스 없이 context 로드 가능하게
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: false
+  mail:
+    host: localhost
+    port: 25
+    username: test
+    password: test
+
+  # awspring이 EC2 인스턴스 메타데이터 조회를 시도하지 않도록
+  cloud:
+    aws:
+      credentials:
+        access-key: test-access-key
+        secret-key: test-secret-key
+      region:
+        static: ap-northeast-2
+
+aws:
+  s3:
+    endpoint: http://localhost:9000
+    public-endpoint: http://localhost:9000
+    bucket: test-bucket
+
+oauth:
+  naver:
+    client-id: test
+    client-secret: test
+    redirect-uri: http://localhost/oauth/naver
+  kakao:
+    client-id: test
+    client-secret: test
+    redirect-uri: http://localhost/oauth/kakao
+
+app:
+  public-base-url: http://localhost:8080
+  order-view-path: /orders/view
+  order-view-token-ttl-minutes: 60
+
+mail:
+  from: test@test.com
+  from-name: 테스트
+
+admin:
+  login-id: admin
+  password: Test1234!
+  email: admin@test.com
+
+jwt:
+  secret: test-secret-key-for-ci-only-minimum-256-bits-long
+  access-expiration-seconds: 3600
+  refresh-expiration-seconds: 1209600

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,10 @@
 # CI/테스트 환경용 설정 — MySQL·AWS·외부 서비스 없이 context 로드 가능하게
 
 spring:
+  application:
+    name: cowmjucraft
+  jackson:
+    time-zone: Asia/Seoul
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE
     driver-class-name: org.h2.Driver
@@ -11,13 +15,16 @@ spring:
       ddl-auto: create-drop
     database-platform: org.hibernate.dialect.H2Dialect
     show-sql: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
   mail:
     host: localhost
     port: 25
     username: test
     password: test
 
-  # awspring이 EC2 인스턴스 메타데이터 조회를 시도하지 않도록
   cloud:
     aws:
       credentials:
@@ -26,7 +33,11 @@ spring:
       region:
         static: ap-northeast-2
 
+server:
+  port: 8080
+
 aws:
+  region: ap-northeast-2
   s3:
     endpoint: http://localhost:9000
     public-endpoint: http://localhost:9000


### PR DESCRIPTION
# 요약

EC2/SSM 배포를 제거하고 Docker Hub + Coolify 기반 CI/CD 파이프라인으로 전환합니다.

# 작업 내용

- [x] `deploy.yml` — EC2/SSM 관련 스텝 전부 제거, Docker Hub push + Coolify webhook 트리거만 유지
- [x] `ci.yml` 신규 추가 — PR 및 non-main 브랜치 push 시 `./gradlew test` 자동 실행
- [x] `build.gradle` — H2 `testRuntimeOnly` 의존성 추가
- [x] `src/test/resources/application.yml` 신규 추가 — CI 환경에서 MySQL·AWS 없이 `@SpringBootTest` context 로드 가능하도록 H2 및 더미 값 설정

# 기타 (논의하고 싶은 부분)

**배포 흐름 변경**
- 기존: GitHub Actions → Docker Hub push → AWS SSM으로 EC2에 직접 배포
- 변경: GitHub Actions → Docker Hub push → Coolify webhook 호출 → Coolify가 pull + redeploy

**테스트 환경**
- `src/test/resources/application.yml`이 H2 + awspring static credentials로 MySQL/AWS 의존성을 대체
- 기존 Mockito 단위 테스트는 영향 없음

# 타 직군 전달 사항

없음

close #