### PR TITLE
chore: ghcr.io로 레지스트리 이전 및 CI/CD 개선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches-ignore: ["main"]
   pull_request:
     branches: ["main"]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build & Push to Docker Hub
+name: Build & Push to ghcr.io
 
 on:
   push:
@@ -8,20 +8,25 @@ concurrency:
   group: deploy-main
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
     env:
-      IMAGE: yunjin1213/cowmjucraft
+      IMAGE: ghcr.io/${{ github.repository_owner }}/cowmjucraft
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/setup-buildx-action@v3
 
@@ -32,6 +37,8 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Trigger Coolify deploy
         run: |


### PR DESCRIPTION
# 요약

Docker Hub → ghcr.io로 레지스트리 이전 및 CI/CD 파이프라인 개선.

# 작업 내용

- [x] `deploy.yml` — Docker Hub 대신 ghcr.io 사용, `GITHUB_TOKEN` 자동 인증으로 별도 시크릿 불필요
- [x] `deploy.yml` — GHA 빌드 캐시 적용으로 반복 빌드 속도 개선
- [x] `ci.yml` — main 브랜치 push 시에도 CI 실행되도록 변경

# 기타 (논의하고 싶은 부분)

없음

# 타 직군 전달 사항

없음

close #