### PR TITLE
fix: ghcr.io 이미지 태그 소문자로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      IMAGE: ghcr.io/${{ github.repository_owner }}/cowmjucraft
+      IMAGE: ghcr.io/cow-mju-craft/cowmjucraft
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
repository_owner가 COW-MJU-Craft로 대문자가 섞여 빌드 실패. 소문자 cow-mju-craft로 하드코딩.