### PR TITLE
chore: 에이전트에 작업 브랜치 push 및 draft PR 생성 위임

### DIFF
--- a/.agents/commands/feature.md
+++ b/.agents/commands/feature.md
@@ -78,10 +78,11 @@ FAIL 항목이 없다면 바로 "승인"이라고 답해주세요.
 
 ---
 
-### STEP 6: PR 초안 작성 (/pr)
+### STEP 6: PR 작성 (/pr)
 커밋 완료 후 /pr을 실행한다.
-PR 초안을 `.ai-workspace/pr.md`에 저장하고 사용자에게 보여준다.
-push와 PR 생성 명령어를 안내하고 종료한다.
+PR 초안을 `.ai-workspace/pr.md`에 저장하고 사용자에게 보여준 뒤,
+승인받으면 push + draft PR 생성까지 실행하고 PR URL을 보고하며 종료한다.
+머지는 사용자가 CI 통과를 확인한 후 직접 한다.
 
 ---
 
@@ -94,5 +95,5 @@ push와 PR 생성 명령어를 안내하고 종료한다.
 ## 주의사항
 - 사용자 확인 없이 단계를 건너뛰거나 자동 진행 금지
 - 어느 단계에서든 사용자가 중단을 요청하면 즉시 중단
-- push 자동 실행 절대 금지
+- 사용자 승인 없는 push 금지, PR 머지 절대 금지
 - 보안 관련 파일(`SecurityConfig`, `JwtAuthenticationFilter`, `JwtTokenProvider`) 수정이 포함된 경우 STEP 2 시작 전 별도 경고

--- a/.agents/commands/pr.md
+++ b/.agents/commands/pr.md
@@ -1,8 +1,9 @@
-# /pr - PR 설명 초안 작성
+# /pr - PR 작성 및 draft PR 생성
 
 ## 역할
-현재 브랜치와 main의 차이를 분석하여 PR 설명 초안을 작성한다.
-push와 `gh pr create`는 사용자가 직접 실행한다.
+현재 브랜치와 main의 차이를 분석하여 PR 설명을 작성하고,
+사용자 승인 후 브랜치 push와 draft PR 생성까지 실행한다.
+**머지는 절대 하지 않는다** — 머지는 사용자의 몫이다.
 
 ## 실행 순서
 
@@ -46,22 +47,31 @@ PR 템플릿을 기반으로 작성하되, 다음 내용을 포함한다.
 - 프론트엔드, 인프라 등 다른 직군에 전달할 사항
 - API 스펙 변경, 환경변수 추가, S3 버킷 설정 변경 등
 
-### 4. 초안 저장 및 보고
-`.ai-workspace/pr.md`에 저장하고 사용자에게 전문을 보여준다.
+### 4. 초안 저장 및 승인 요청
+`.ai-workspace/pr.md`에 저장하고 사용자에게 전문을 보여준 뒤 다음 메시지로 대기한다.
 (`.ai-workspace/` 디렉토리가 없으면 생성 후 저장)
 
-### 5. push 및 PR 생성 안내
-사용자가 직접 실행할 명령어를 안내한다.
-```bash
-# 브랜치 push
-git push origin <브랜치명>
-
-# PR 생성 (gh CLI 사용 시)
-gh pr create --title "<제목>" --body "$(cat .ai-workspace/pr.md)"
+```
+PR 초안입니다. "승인"이라고 답하시면 push 후 draft PR을 생성합니다.
 ```
 
+### 5. push 및 draft PR 생성 (사용자 승인 후에만)
+```bash
+git push -u origin <브랜치명>
+
+# 에이전트 라벨 준비 (없으면 생성)
+gh label create "agent:claude-code" --color "D97706" --description "Claude Code가 작성한 PR" 2>/dev/null || true
+gh label create "agent:codex" --color "6366F1" --description "Codex가 작성한 PR" 2>/dev/null || true
+
+# draft PR 생성 — 자신에 맞는 라벨 사용 (Claude Code면 agent:claude-code, Codex면 agent:codex)
+gh pr create --draft --title "<제목>" --body-file .ai-workspace/pr.md --label "agent:claude-code"
+```
+
+생성된 PR URL을 사용자에게 보고하고 종료한다.
+
 ## 주의사항
-- push 자동 실행 절대 금지
-- `gh pr create` 자동 실행 절대 금지
+- 사용자 승인 없이 push/PR 생성 금지
+- PR 머지(`gh pr merge`) 절대 금지
+- main으로의 직접 push 절대 금지
 - 1000줄 이상 diff인 경우 전체 분석 대신 `--stat` 기반으로 요약하고 사용자에게 알림
 - main 브랜치에서 실행 중이라면 경고 후 중단

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,15 +10,22 @@
       "Bash(git diff:*)",
       "Bash(git log:*)",
       "Bash(git branch:*)",
-      "Bash(git switch:*)"
+      "Bash(git switch:*)",
+      "Bash(git push origin:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh label create:*)"
     ],
     "deny": [
-      "Bash(git push:*)",
       "Bash(git commit --no-verify:*)",
       "Bash(git config core.hooksPath:*)",
       "Read(./.env)",
       "Read(./src/main/resources/application-local.yml)",
-      "Read(./src/main/resources/application-prod.yml)"
+      "Read(./src/main/resources/application-prod.yml)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push origin main:*)",
+      "Bash(git push origin HEAD:main:*)",
+      "Bash(gh pr merge:*)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,12 +370,17 @@ void createOrder_재고부족_OrderException발생() {
 
 다음 행동은 어떤 상황에서도 금지된다.
 
-1. **자동 push 금지** — `git push`는 사용자가 직접 실행
+1. **main 병합은 사람만** — PR 머지는 사용자가 직접 실행, 에이전트는 절대 병합하지 않는다
 2. **force push 금지** — `git push --force` 절대 실행 금지
-3. **main 직접 커밋 금지** — main 브랜치에 직접 commit 금지
+3. **main 직접 커밋/push 금지** — main 브랜치에 직접 commit·push 금지 (서버 ruleset으로도 차단됨)
 4. **민감정보 커밋 금지** — API 키, 비밀번호, JWT 시크릿, DB 접속 정보, AWS 자격증명 등 커밋 금지
 5. **보안 변경 사람 리뷰 필수** — `SecurityConfig`, `JwtAuthenticationFilter`, `JwtTokenProvider` 수정 시 반드시 사람이 리뷰 후 병합
 6. **커밋 전 사용자 승인 필수** — 커밋 메시지 제안 후 승인 대기, 자동 커밋 금지
+
+**허용되는 것** (2026-07 개정)
+- 작업 브랜치(`feat/*`, `fix/*` 등)로의 push — 커밋이 사용자 승인을 받았다면 허용
+- `gh pr create --draft` — draft PR 생성 허용, 단 라벨(`agent:claude-code` 또는 `agent:codex`)을 붙인다
+- main은 branch ruleset(PR 필수 + CI 필수 + force push 차단)이 서버에서 보호하므로, 위 위임이 가능하다
 
 ---
 
@@ -398,4 +403,4 @@ void createOrder_재고부족_OrderException발생() {
 - 커맨드 파일 내용이 AGENTS.md와 충돌하면 AGENTS.md를 우선한다.
 - 커맨드 파일을 읽었더라도 절대 규칙은 항상 유지한다.
 - `/commit`은 커밋 메시지 제안 후 사용자 승인을 받은 경우에만 실행한다.
-- `/pr`은 PR 초안만 작성하고, push 및 `gh pr create`는 실행하지 않는다.
+- `/pr`은 브랜치 push 후 draft PR 생성까지 실행한다. 머지는 하지 않는다.

--- a/docs/agent-harness-handoff.md
+++ b/docs/agent-harness-handoff.md
@@ -35,7 +35,7 @@
 
 ## 남은 Phase (계획서 참고: docs/agent-harness-plan.md)
 
-- **Phase 5** (branch protection 활성화 후): 절대 규칙 완화 — feat/* push 허용, draft PR 생성 허용, 에이전트 라벨. `.claude/settings.json`의 `git push` deny 제거 포함
+- ~~Phase 5~~ 완료 (2026-07-09): 작업 브랜치 push·draft PR 생성 위임, 에이전트 라벨(`agent:claude-code`/`agent:codex`), 머지·force push·main push는 계속 금지
 - **Phase 6** (컨벤션 위반이 반복될 때): JPA/트랜잭션/로깅 컨벤션, Spotless, ArchUnit, skills
 
 ## 참고


### PR DESCRIPTION
# 요약

branch ruleset(PR 필수 + CI 필수 + force push 차단)이 활성화됨에 따라, 에이전트에게 작업 브랜치 push와 draft PR 생성까지 위임합니다. 머지·main push·force push는 계속 금지(서버에서도 차단)입니다.

# 작업 내용

- [ ] AGENTS.md 절대 규칙 개정 — "자동 push 금지" → "main 병합은 사람만"으로 재정의, 승인된 커밋의 작업 브랜치 push와 `gh pr create --draft` 허용 명시
- [ ] `/pr` 커맨드 개정 — 초안 승인 후 push → 에이전트 라벨 생성/부착(`agent:claude-code`/`agent:codex`) → draft PR 생성 → PR URL 보고까지 실행
- [ ] `/feature` 워크플로우 — STEP 6에서 PR URL 보고까지 원스톱 연결
- [ ] `.claude/settings.json` — `git push origin`·`gh pr create` allow, `git push --force`·main push·`gh pr merge` deny

# 기타 (논의하고 싶은 부분)

- draft PR 기본 정책: 에이전트 PR은 항상 draft로 생성 → 사용자가 Ready for review 전환 후 머지
- 첫 /pr 실행 시 `agent:*` 라벨이 자동 생성됨 (gh label create)

# 타 직군 전달 사항

- 없음 (에이전트 워크플로우 설정 변경만 포함)
