### PR TITLE
ci: PR CI에 Docker 이미지 빌드 검증 job 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,17 @@ jobs:
           test -L .codex/commands && test -e .codex/commands || { echo "::error::.codex/commands 심링크 깨짐"; exit 1; }
           grep -q "@AGENTS.md" CLAUDE.md || { echo "::error::CLAUDE.md에 @AGENTS.md import 없음"; exit 1; }
           echo "OK"
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Docker 이미지 빌드 검증 (push 없음)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha


### PR DESCRIPTION
# 요약
PR CI에서 Docker 이미지를 push 없이 빌드해 Dockerfile·패키징 파손을 merge 전에 발견합니다.

# 작업 내용
- [x] ci.yml에 docker-build job 추가 (buildx, push: false, gha 캐시 공유)

# 기타 (논의하고 싶은 부분)
병합 후 main ruleset 필수 체크에 `docker-build` 추가 필요 (수동 설정).

# 타 직군 전달 사항
없음