### PR TITLE
feat: actuator health 및 배포 후 smoke check 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,3 +44,21 @@ jobs:
         run: |
           curl -fSs -X GET "${{ secrets.COOLIFY_WEBHOOK_URL }}" \
             -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}"
+
+      - name: Verify deployment (smoke check)
+        run: |
+          BASE_URL="${{ vars.PROD_BASE_URL || 'https://mju-craft.shop' }}"
+          echo "smoke target: ${BASE_URL}/api/projects"
+          # Coolify 배포·컨테이너 기동 대기 후 운영 API가 200을 반환하는지 확인
+          ok=""
+          for i in $(seq 1 20); do
+            sleep 15
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${BASE_URL}/api/projects" || echo 000)
+            echo "attempt ${i}/20: HTTP ${code}"
+            if [ "$code" = "200" ]; then ok=1; break; fi
+          done
+          if [ -z "$ok" ]; then
+            echo "::error::배포 후 smoke check 실패 — 운영 API가 5분 내 200을 반환하지 않음"
+            exit 1
+          fi
+          echo "smoke check OK"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,18 @@ RUN ./gradlew clean bootJar -x test
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080
+
+# 컨테이너 자체 헬스체크 — Coolify가 기동 실패를 감지할 수 있게 함
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=3 \
+  CMD curl -fsS http://localhost:8080/actuator/health || exit 1
+
 ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,12 @@ aws:
     public-endpoint: ${AWS_S3_PUBLIC_ENDPOINT}
     bucket: ${AWS_S3_BUCKET}
 
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
# 요약
배포가 "요청 성공"이 아니라 "실제 서비스 정상"까지 확인하도록 합니다.

# 작업 내용
- [x] spring-boot-starter-actuator 추가, /actuator/health 노출
- [x] Dockerfile HEALTHCHECK 추가 (Coolify가 기동 실패 감지 가능)
- [x] deploy.yml에 운영 /api/projects 200 폴링(최대 5분) smoke check

# 기타 (논의하고 싶은 부분)
운영 주소가 https://mju-craft.shop 이 아니면 repo Variable `PROD_BASE_URL` 설정 필요.
한계: 구버전 컨테이너가 서빙 중이어도 200이면 통과 — 버전 검증은 후속 작업.

# 타 직군 전달 사항
없음