### PR TITLE
ci: deploy를 main CI 성공 이후에만 실행

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,10 @@
 name: Build & Push to ghcr.io
 
+# main push 직접 트리거 대신 CI 성공 이후에만 실행
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: ["main"]
 
 concurrency:
@@ -14,6 +17,8 @@ permissions:
 
 jobs:
   build-and-push:
+    # CI가 성공한 경우에만 배포
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     env:
@@ -21,6 +26,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # CI가 검증한 바로 그 커밋을 빌드 (트리거 시점의 main HEAD가 아니라)
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: docker/login-action@v3
         with:
@@ -36,7 +44,7 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:${{ github.event.workflow_run.head_sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
# 요약
deploy 워크플로우가 main CI 성공 이후에만 실행되도록 트리거를 변경합니다.

# 작업 내용
- [x] push 트리거 → workflow_run(CI completed, main) + conclusion == success 게이트
- [x] checkout·이미지 태그를 CI가 검증한 head_sha로 고정

# 기타 (논의하고 싶은 부분)
없음

# 타 직군 전달 사항
없음