### PR TITLE
docs: AGENTS.md 최신화 및 핸드오프 문서 아카이브

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 | Java | 21 |
 | 빌드 도구 | Gradle (Groovy DSL), 단일 모듈 |
 | 데이터베이스 | MySQL |
-| 인증 | JWT (jjwt 0.11.5) + Spring Security |
+| 인증 | JWT (jjwt 0.11.5) + Spring Security — 관리자 로그인만 존재, 소셜(OAuth) 로그인 없음 |
 | 파일 스토리지 | AWS S3 (spring-cloud-aws) |
 | 모듈 구조 | 단일 모듈 |
 
@@ -53,6 +53,12 @@
 ./gradlew build -x test
 ```
 
+**최초 셋업 (clone 후 1회)**
+```bash
+bash scripts/setup-hooks.sh   # pre-commit 훅 활성화 (main 커밋 차단·시크릿 차단)
+```
+- 로컬에 gitleaks가 없으면 훅은 grep 폴백으로 동작한다 (`brew install gitleaks` 권장)
+
 ---
 
 ## 패키지 / 모듈 구조
@@ -61,35 +67,27 @@
 com.example.cowmjucraft
 ├── CowMjuCraftApplication.java
 ├── domain/                             # 비즈니스 도메인
-│   ├── accounts/                       # 계정/인증
+│   ├── accounts/                       # 계정/인증 (관리자 전용 — 일반 사용자 계정 없음)
 │   │   ├── admin/
 │   │   │   ├── account/               # 관리자 계정 관리
-│   │   │   │   ├── controller/
-│   │   │   │   ├── service/
-│   │   │   │   ├── dto/request|response/
-│   │   │   │   ├── entity/
-│   │   │   │   └── repository/
-│   │   │   └── auth/                  # 관리자 인증 (로그인/토큰)
-│   │   ├── auth/                      # RefreshToken 등 공통 인증
-│   │   ├── user/                      # 일반 사용자 (OAuth 포함)
-│   │   │   ├── entity/
-│   │   │   ├── repository/
-│   │   │   └── oauth/
+│   │   │   ├── auth/                  # 관리자 인증 (로그인/토큰)
+│   │   │   ├── entity/                # Admin
+│   │   │   └── repository/
+│   │   ├── auth/                      # RefreshToken 저장/발급
 │   │   └── exception/
 │   ├── common/                         # 공통 엔티티 (BaseTimeEntity)
 │   ├── feedback/                       # 피드백
-│   ├── introduce/                      # 소개
-│   ├── item/                           # 프로젝트 물품
-│   ├── mypage/                         # 마이페이지
+│   ├── introduce/                      # 소개 페이지
+│   ├── item/                           # 프로젝트 물품 (ProjectItem, ItemImage)
 │   ├── notice/                         # 공지사항
-│   ├── order/                          # 주문
-│   ├── payout/                         # 정산
+│   ├── order/                          # 주문 (Order + Auth/Buyer/Fulfillment/Item/ViewToken/CompletePage)
+│   ├── payout/                         # 정산 (Payout, PayoutItem)
 │   ├── project/                        # 프로젝트
-│   ├── recruit/                        # 모집
-│   └── sns/                            # SNS 연동
+│   ├── recruit/                        # 모집/지원 (Form, Question, Application, Answer)
+│   └── sns/                            # SNS 링크
 └── global/                             # 공통/인프라
     ├── cloud/                          # S3 설정 및 서비스
-    ├── config/                         # Spring 설정 (Security, CORS, Swagger, JWT)
+    ├── config/                         # Spring 설정 (Security, CORS, Swagger, Jackson, JPA Auditing)
     │   └── jwt/                        # JwtAuthenticationFilter, JwtTokenProvider
     ├── exception/                      # DomainException, GlobalExceptionHandler
     ├── response/                       # ApiResponse(팩토리), ApiResult(래퍼), type/
@@ -116,17 +114,15 @@ domain/{도메인}/
 | 도메인 | 책임 |
 |---|---|
 | `accounts/admin` | 관리자 계정 생성, 관리자 로그인/토큰 |
-| `accounts/user` | 일반 사용자 엔티티, OAuth 로그인 |
 | `accounts/auth` | RefreshToken 저장소 |
 | `item` | 프로젝트 물품 CRUD, S3 Presign |
 | `project` | 프로젝트 CRUD |
 | `order` | 주문 생성/조회 |
 | `payout` | 정산 처리 |
-| `recruit` | 모집 공고 |
+| `recruit` | 모집 공고, 지원서 접수/결과 |
 | `feedback` | 피드백 |
 | `notice` | 공지사항 |
 | `introduce` | 소개 페이지 |
-| `mypage` | 마이페이지 (주문내역, 프로필) |
 | `sns` | SNS 링크 관리 |
 | `global` | 설정, 공통 응답, 예외 핸들러, JWT, S3 |
 
@@ -404,3 +400,29 @@ void createOrder_재고부족_OrderException발생() {
 - 커맨드 파일을 읽었더라도 절대 규칙은 항상 유지한다.
 - `/commit`은 커밋 메시지 제안 후 사용자 승인을 받은 경우에만 실행한다.
 - `/pr`은 브랜치 push 후 draft PR 생성까지 실행한다. 머지는 하지 않는다.
+
+---
+
+## DB 스키마 변경 규칙 (Flyway)
+
+> Flyway 도입 PR 병합 후 적용된다.
+
+- 스키마 변경은 **반드시** `src/main/resources/db/migration/V{N}__{설명}.sql` 마이그레이션 파일로만 한다
+- 엔티티만 수정하고 마이그레이션 파일을 빠뜨리면 운영 배포가 validate 오류로 실패한다
+- 이미 병합된 마이그레이션 파일은 절대 수정하지 않는다 — 새 버전 파일을 추가한다
+- 운영 프로필은 `ddl-auto: validate` — Hibernate가 스키마를 변경하는 일은 없어야 한다
+- 마이그레이션 검증은 CI의 Testcontainers MySQL 테스트가 수행한다
+
+---
+
+## 핸드오프/상태 문서 컨벤션
+
+에이전트가 작업 인계 문서(핸드오프, 계획, 상태 파일)를 작성할 때:
+
+1. **기준점 기록 필수** — 문서 상단에 작성 시각, 기준 브랜치, HEAD SHA를 적는다
+   ```
+   > 작성: 2026-07-11 · 브랜치: chore/xxx · 기준 HEAD: abc1234
+   ```
+2. **완료 처리 규칙 명시** — 문서가 언제 효력을 잃는지, 완료 시 어떻게 처리할지(배너 후 아카이브 또는 삭제) 문서 안에 적는다
+3. **완료된 핸드오프는 즉시 닫는다** — 체크리스트가 끝나면 상단에 `✅ 완료 (날짜, 병합 PR)` 배너를 달거나 삭제한다. 완료 상태로 방치된 핸드오프는 다음 에이전트에게 틀린 컨텍스트를 준다
+4. **영구 정보는 이 파일(AGENTS.md)로 이관** — 일회성 문서에 영구 규칙을 남기지 않는다

--- a/docs/agent-harness-handoff.md
+++ b/docs/agent-harness-handoff.md
@@ -1,3 +1,7 @@
+> ✅ **완료됨 (2026-07-11 확인)** — 이 문서의 모든 작업은 push·병합되어 main에 반영됐다.
+> 아침 체크리스트 완료: CI 3개 job 활성, main ruleset 활성(필수 체크: test·secret-scan·agent-config), diff-cover는 실제 coverage 부족 PR 차단 이력으로 검증됨.
+> 영구 정보(setup-hooks, gitleaks 폴백)는 AGENTS.md로 이관됨. 이 문서는 기록용 아카이브다.
+
 # 에이전트 하네스 작업 핸드오프 (2026-07-09 새벽 작업분)
 
 `chore/agent-harness` 브랜치에 Phase 1~4 완료. **push는 안 했음** — 아래 체크리스트 순서대로 진행하면 됨.

--- a/docs/cicd-refactoring-plan.md
+++ b/docs/cicd-refactoring-plan.md
@@ -1,0 +1,57 @@
+# CI/CD·하네스 리팩토링 계획
+
+> 작성: 2026-07-11 · 기준: origin/main `c24e528` (PR #116 머지 시점)
+> 근거: Claude·Codex 교차 리뷰 수렴 결과. 완료 시 이 문서 상단에 ✅ 배너를 달고 아카이브할 것.
+
+## 현재 평가 (백엔드)
+
+| 영역 | 점수 | 비고 |
+|---|---:|---|
+| CI 게이트 | 7.0/10 | diff-coverage 70%·gitleaks 실제 차단 이력 있음 |
+| CD | 4.5/10 | "검증된 배포"가 아닌 "배포 요청 자동화" |
+| 하네스 | 7.2/10 | 안전장치는 좋으나 컨텍스트 신선도 낮음 |
+
+핵심 진단: 문제는 CI–deploy 분리가 아니라, **PR CI가 배포 산출물(Docker 이미지)을 검증하지 않고, deploy가 배포 완료를 확인하지 않는 것**. 그리고 `ddl-auto: update`가 유일한 비가역 리스크.
+
+## 작업 목록 (실행 순서)
+
+### ① 배포 후 health 폴링 + smoke check — 반나절
+- `spring-boot-starter-actuator` 추가, `/actuator/health` 노출
+- deploy.yml 마지막 스텝: 운영 URL 30초 간격 폴링(최대 5분) + `/api/projects` 200 확인, 실패 시 워크플로우 실패
+- 효과: "Actions 초록불 = 실제 서비스 정상" 보장. 현재는 컨테이너 부팅 실패해도 초록불.
+
+### ② PR CI에 Docker build 검증 — 1시간
+- ci.yml에 `docker build .` job 추가 (push 없음)
+- 효과: Dockerfile·패키징 파손을 merge 전에 발견. GHCR 이미지명 대문자 문제로 배포 빌드 깨졌던 사례 재발 방지.
+- 비용: PR CI 2~3분 증가.
+
+### ③ Flyway 도입 + prod `ddl-auto: validate` — 가장 신중하게
+- Flyway 의존성 추가 → 운영 스키마 덤프로 `V1__baseline.sql` 생성 → `baseline-on-migrate` 설정 → prod를 `validate`로 전환
+- 이후 모든 스키마 변경은 마이그레이션 파일로 (코드 리뷰 대상화)
+- 효과: **유일하게 데이터 손상을 막는 항목.** 현재는 엔티티 수정 시 Hibernate가 운영 DB를 이력 없이 변경. 롤백 시 DB 호환성 판단 기준 확보.
+
+### ④ Testcontainers MySQL 테스트 1개 — ③ 이후, 1~2시간
+- 빈 MySQL 컨테이너에 migration 전체 적용 → Spring context 기동 → 핵심 repository 쿼리 1~2개 확인
+- 효과: H2–MySQL 동작 차이, migration 파손 조기 발견. GitHub runner에 Docker 내장이라 CI에서 그대로 동작.
+- 주의: ③ 없이 넣으면 `ddl-auto: update`가 스키마를 자동 보정해 검증 가치가 없음.
+
+### ⑤ AGENTS.md 최신화 + 핸드오프 문서 정리 — 1~2시간
+- 실제 `src/main/java` 구조 기준으로 모듈 트리·표 재작성. 제거된 OAuth·`accounts/user`·`mypage` 삭제 (AGENTS.md 73~129행 부근)
+- `docs/agent-harness-handoff.md`: 작업 완료·main 머지 상태이므로 ✅ 배너 후 아카이브(또는 삭제). 영구 정보 2개만 AGENTS.md로 이관: clone 후 `bash scripts/setup-hooks.sh` 필요, gitleaks 미설치 시 grep 폴백
+- 하네스 컨벤션 추가: 핸드오프/상태 문서에 작성 시점 HEAD SHA·브랜치 기록, 완료 시 처리 규칙 명시
+- 효과: 에이전트가 존재하지 않는 구조를 전제로 계획하는 stale-context 실패 모드 제거.
+
+### ⑥ deploy를 CI 성공 뒤로 연결 — 30분, 마지막
+- deploy.yml 트리거를 `workflow_run`(CI 완료 + `conclusion == success`)으로 변경
+- 효과: merge skew·직접 push 구멍 봉합. 단독 효과는 작아 마지막 순서.
+
+## 하지 않기로 한 것
+
+- 기존 코드 커버리지(line ~11%) 끌어올리기 캠페인 — diff 70% 게이트가 자연히 해결
+- MinIO Testcontainers — presign/업로드 실제 장애가 반복될 때
+- 자동 롤백·staging·canary — 현 규모에 과잉. 롤백은 "Coolify에서 이전 SHA 이미지 재배포" 절차를 문서 한 단락으로 기록
+- 보안 경로 승인 게이트 — 솔로 운영이라 승인 0명 유지 (2인 이상 되면 CODEOWNERS + 승인 1명)
+
+## 완료 기준
+
+①~⑥ 반영 후: 배포 실패가 Actions에서 빨간불로 보이고, 스키마 변경이 전부 마이그레이션 파일로 남으며, AGENTS.md가 실제 코드 구조와 일치. 예상 평가 CI/CD 6.0 → 7점대.


### PR DESCRIPTION
# 요약
AGENTS.md의 stale 컨텍스트(제거된 OAuth·mypage)를 정리하고 하네스 컨벤션을 추가합니다.

# 작업 내용
- [x] 패키지 구조·도메인 표를 실제 코드 기준으로 재작성
- [x] 셋업 정보(setup-hooks, gitleaks 폴백)를 핸드오프 문서에서 이관
- [x] DB 마이그레이션 규칙·핸드오프 문서 컨벤션 추가
- [x] agent-harness-handoff.md 완료 배너, CI/CD 리팩토링 계획 문서 추가

# 기타 (논의하고 싶은 부분)
없음

# 타 직군 전달 사항
없음