### PR TITLE
fix: smoke check를 실제 API 도메인과 JSON 응답 검증으로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,15 +55,20 @@ jobs:
 
       - name: Verify deployment (smoke check)
         run: |
-          BASE_URL="${{ vars.PROD_BASE_URL || 'https://mju-craft.shop' }}"
+          BASE_URL="${{ vars.PROD_BASE_URL || 'https://api.mju-craft.shop' }}"
           echo "smoke target: ${BASE_URL}/api/projects"
-          # Coolify 배포·컨테이너 기동 대기 후 운영 API가 200을 반환하는지 확인
+          # Coolify 배포·컨테이너 기동 대기 후 운영 API가 "실제 JSON"을 반환하는지 확인.
+          # HTTP 200만 보면 안 됨 — 프런트 도메인은 SPA fallback이 모든 경로에 200 HTML을 반환함.
           ok=""
           for i in $(seq 1 20); do
             sleep 15
-            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${BASE_URL}/api/projects" || echo 000)
-            echo "attempt ${i}/20: HTTP ${code}"
-            if [ "$code" = "200" ]; then ok=1; break; fi
+            body=$(curl -s --max-time 10 "${BASE_URL}/api/projects" || echo "")
+            if echo "$body" | grep -q '"resultType":"SUCCESS"'; then
+              echo "attempt ${i}/20: JSON OK"
+              ok=1
+              break
+            fi
+            echo "attempt ${i}/20: 아직 JSON 응답 아님"
           done
           if [ -z "$ok" ]; then
             echo "::error::배포 후 smoke check 실패 — 운영 API가 5분 내 200을 반환하지 않음"


### PR DESCRIPTION
# 요약
smoke check가 프런트 도메인의 SPA fallback(모든 경로 200 HTML)을 보고 통과하던 문제를 수정합니다.

# 작업 내용
- [x] 기본 URL을 api.mju-craft.shop으로 변경
- [x] HTTP 200 대신 응답 본문 resultType SUCCESS 검증으로 강화

# 기타 (논의하고 싶은 부분)
직전 배포의 smoke check 초록불은 가짜였습니다(HTML 200). 이 PR 이후부터 유효합니다.

# 타 직군 전달 사항
없음