### PR TITLE
chore: Flyway 도입 및 운영 ddl-auto validate 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,8 @@ dependencies {
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
-	implementation 'org.flywaydb:flyway-core'
+	// Boot 4 모듈화: flyway-core만으로는 자동설정이 활성화되지 않음 — starter 필수
+	implementation 'org.springframework.boot:spring-boot-starter-flyway'
 	runtimeOnly 'org.flywaydb:flyway-mysql'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	implementation 'org.flywaydb:flyway-core'
+	runtimeOnly 'org.flywaydb:flyway-mysql'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'

--- a/src/main/java/com/example/cowmjucraft/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/example/cowmjucraft/domain/feedback/entity/Feedback.java
@@ -35,7 +35,7 @@ public class Feedback {
     private FeedbackStatus status = FeedbackStatus.RECEIVED;
 
     @Lob
-    @Column
+    @Column(columnDefinition = "LONGTEXT")
     private String answer;
 
     public Feedback(String title, String content) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,6 +14,11 @@ spring:
       ddl-auto: update
     show-sql: true
 
+  # 로컬은 개발 편의상 ddl-auto: update 유지, flyway 미적용.
+  # 마이그레이션 파일 검증은 CI의 Testcontainers 테스트가 담당.
+  flyway:
+    enabled: false
+
   mail:
     host: ${MAIL_HOST}
     port: ${MAIL_PORT}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,8 +10,15 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: false
+
+  flyway:
+    enabled: true
+    # 기존 운영 DB(테이블 존재)는 V1을 실행하지 않고 기준점(1)만 기록.
+    # 빈 DB에서는 V1부터 전부 실행됨.
+    baseline-on-migrate: true
+    baseline-version: 1
 
   mail:
     host: ${MAIL_HOST}

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -5,9 +5,11 @@
 --   (CamelCase→snake_case, @Enumerated(STRING)→ENUM, @Lob String→LONGTEXT,
 --    boolean→BIT(1), LocalDateTime→DATETIME(6))
 --
--- ⚠️ 운영 반영 전 필수 검증:
---   mysqldump --no-data --skip-comments <prod_db> 결과와 이 파일을 대조할 것.
---   컬럼 존재·타입이 일치해야 함 (제약조건/인덱스 "이름" 차이는 무해).
+-- ✅ 운영 스키마 대조 완료 (2026-07-11, IntelliJ Generate DDL 덤프 기준):
+--   enum 값 순서·nullable·ON DELETE CASCADE를 운영과 일치시킴.
+--   운영에만 있는 레거시 테이블(users, member_addresses)은 baseline에서 제외 —
+--   validate는 여분 테이블을 무시함. 정리는 별도 결정 사항.
+--   운영과 엔티티의 드리프트(BASIC 누락, answer TINYTEXT)는 V2에서 수정.
 --   운영 DB에는 baseline-on-migrate=true 로 이 파일이 실행되지 않고
 --   기준점으로만 기록됨. 실제 실행 대상은 빈 DB(테스트·신규 환경)뿐.
 -- =====================================================================
@@ -17,7 +19,7 @@ CREATE TABLE admins (
     login_id VARCHAR(255) NOT NULL,
     password VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL,
-    role ENUM('ROLE_ADMIN') NOT NULL,
+    role ENUM('ROLE_ADMIN','ROLE_USER') NOT NULL,
     PRIMARY KEY (id),
     UNIQUE KEY uk_admins_login_id (login_id),
     UNIQUE KEY uk_admins_email (email)
@@ -38,9 +40,9 @@ CREATE TABLE refresh_tokens (
 CREATE TABLE feedbacks (
     id BIGINT NOT NULL AUTO_INCREMENT,
     title VARCHAR(255) NOT NULL,
-    content TEXT NOT NULL,
-    status ENUM('RECEIVED','ANSWERED') NOT NULL,
-    answer LONGTEXT,
+    content TEXT,
+    status ENUM('ANSWERED','RECEIVED') NOT NULL,
+    answer TINYTEXT,
     PRIMARY KEY (id)
 ) ENGINE=InnoDB;
 
@@ -64,7 +66,7 @@ CREATE TABLE projects (
     description TEXT NOT NULL,
     thumbnail_key VARCHAR(255) NOT NULL,
     deadline_date DATE NOT NULL,
-    status ENUM('PREPARING','OPEN','CLOSED') NOT NULL,
+    status ENUM('CLOSED','OPEN','PREPARING') NOT NULL,
     category ENUM('GOODS','JOURNAL') NOT NULL,
     pinned BIT(1) NOT NULL,
     pinned_order INT,
@@ -89,9 +91,9 @@ CREATE TABLE project_items (
     summary VARCHAR(200),
     description MEDIUMTEXT NOT NULL,
     price INT NOT NULL,
-    sale_type ENUM('NORMAL','GROUPBUY') NOT NULL,
-    status ENUM('PREPARING','OPEN','CLOSED') NOT NULL,
-    item_type ENUM('PHYSICAL','DIGITAL_JOURNAL') NOT NULL,
+    sale_type ENUM('GROUPBUY','NORMAL') NOT NULL,
+    status ENUM('CLOSED','OPEN','PREPARING') NOT NULL,
+    item_type ENUM('DIGITAL_JOURNAL','PHYSICAL') NOT NULL,
     thumbnail_key VARCHAR(255),
     journal_file_key VARCHAR(255),
     target_qty INT,
@@ -100,7 +102,7 @@ CREATE TABLE project_items (
     created_at DATETIME(6),
     updated_at DATETIME(6),
     PRIMARY KEY (id),
-    CONSTRAINT fk_project_items_project FOREIGN KEY (project_id) REFERENCES projects (id)
+    CONSTRAINT fk_project_items_project FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
 CREATE TABLE item_images (
@@ -111,7 +113,7 @@ CREATE TABLE item_images (
     created_at DATETIME(6),
     updated_at DATETIME(6),
     PRIMARY KEY (id),
-    CONSTRAINT fk_item_images_item FOREIGN KEY (item_id) REFERENCES project_items (id)
+    CONSTRAINT fk_item_images_item FOREIGN KEY (item_id) REFERENCES project_items (id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
 CREATE TABLE notices (
@@ -184,7 +186,7 @@ CREATE TABLE order_auth (
 
 CREATE TABLE order_buyer (
     order_id BIGINT NOT NULL,
-    buyer_type ENUM('STUDENT','STAFF','EXTERNAL') NOT NULL,
+    buyer_type ENUM('EXTERNAL','STAFF','STUDENT') NOT NULL,
     campus VARCHAR(50),
     name VARCHAR(100) NOT NULL,
     department_or_major VARCHAR(100),
@@ -201,7 +203,7 @@ CREATE TABLE order_buyer (
 
 CREATE TABLE order_fulfillment (
     order_id BIGINT NOT NULL,
-    method ENUM('PICKUP','DELIVERY') NOT NULL,
+    method ENUM('DELIVERY','PICKUP') NOT NULL,
     receiver_name VARCHAR(100) NOT NULL,
     receiver_phone VARCHAR(50) NOT NULL,
     info_confirmed BIT(1) NOT NULL,
@@ -253,7 +255,7 @@ CREATE TABLE payouts (
 CREATE TABLE payout_items (
     id BIGINT NOT NULL AUTO_INCREMENT,
     payout_id BIGINT NOT NULL,
-    type ENUM('INCOME','EXPENSE') NOT NULL,
+    type ENUM('EXPENSE','INCOME') NOT NULL,
     name VARCHAR(100) NOT NULL,
     amount BIGINT NOT NULL,
     category VARCHAR(50),
@@ -280,10 +282,10 @@ CREATE TABLE form_questions (
     form_id BIGINT NOT NULL,
     question_id BIGINT NOT NULL,
     question_order INT NOT NULL,
-    answer_type ENUM('TEXT','FILE','SELECT') NOT NULL,
+    answer_type ENUM('FILE','SELECT','TEXT') NOT NULL,
     required BIT(1) NOT NULL,
-    section_type ENUM('BASIC','COMMON','DEPARTMENT') NOT NULL,
-    department_type ENUM('MARKETING','DESIGN','FINANCE','OPERATION'),
+    section_type ENUM('COMMON','DEPARTMENT') NOT NULL,
+    department_type ENUM('DESIGN','FINANCE','MARKETING','OPERATION'),
     select_options VARCHAR(2000),
     PRIMARY KEY (id),
     CONSTRAINT fk_form_questions_form FOREIGN KEY (form_id) REFERENCES forms (id),
@@ -293,8 +295,8 @@ CREATE TABLE form_questions (
 CREATE TABLE form_notice (
     id BIGINT NOT NULL AUTO_INCREMENT,
     form_id BIGINT NOT NULL,
-    section_type ENUM('BASIC','COMMON','DEPARTMENT') NOT NULL,
-    department_type ENUM('MARKETING','DESIGN','FINANCE','OPERATION'),
+    section_type ENUM('COMMON','DEPARTMENT') NOT NULL,
+    department_type ENUM('DESIGN','FINANCE','MARKETING','OPERATION'),
     title VARCHAR(100) NOT NULL,
     content TEXT,
     PRIMARY KEY (id),
@@ -306,9 +308,9 @@ CREATE TABLE applications (
     form_id BIGINT NOT NULL,
     student_id VARCHAR(255) NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
-    first_department ENUM('MARKETING','DESIGN','FINANCE','OPERATION') NOT NULL,
-    second_department ENUM('MARKETING','DESIGN','FINANCE','OPERATION') NOT NULL,
-    result_status ENUM('NOT_PUBLISHED','PASS','FAIL') NOT NULL,
+    first_department ENUM('DESIGN','FINANCE','MARKETING','OPERATION') NOT NULL,
+    second_department ENUM('DESIGN','FINANCE','MARKETING','OPERATION') NOT NULL,
+    result_status ENUM('FAIL','NOT_PUBLISHED','PASS') NOT NULL,
     created_at DATETIME(6),
     updated_at DATETIME(6),
     PRIMARY KEY (id),

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,335 @@
+-- =====================================================================
+-- V1: baseline schema (2026-07-11)
+--
+-- 생성 근거: JPA 엔티티(25개) 수작업 변환 — Hibernate 7 MySQL 매핑 규칙 기준
+--   (CamelCase→snake_case, @Enumerated(STRING)→ENUM, @Lob String→LONGTEXT,
+--    boolean→BIT(1), LocalDateTime→DATETIME(6))
+--
+-- ⚠️ 운영 반영 전 필수 검증:
+--   mysqldump --no-data --skip-comments <prod_db> 결과와 이 파일을 대조할 것.
+--   컬럼 존재·타입이 일치해야 함 (제약조건/인덱스 "이름" 차이는 무해).
+--   운영 DB에는 baseline-on-migrate=true 로 이 파일이 실행되지 않고
+--   기준점으로만 기록됨. 실제 실행 대상은 빈 DB(테스트·신규 환경)뿐.
+-- =====================================================================
+
+CREATE TABLE admins (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    login_id VARCHAR(255) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    role ENUM('ROLE_ADMIN') NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_admins_login_id (login_id),
+    UNIQUE KEY uk_admins_email (email)
+) ENGINE=InnoDB;
+
+CREATE TABLE refresh_tokens (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    subject VARCHAR(128) NOT NULL,
+    role ENUM('ROLE_ADMIN') NOT NULL,
+    token_hash VARCHAR(64) NOT NULL,
+    expires_at DATETIME(6) NOT NULL,
+    revoked_at DATETIME(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_refresh_tokens_token_hash (token_hash),
+    KEY idx_refresh_tokens_subject_role (subject, role)
+) ENGINE=InnoDB;
+
+CREATE TABLE feedbacks (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    status ENUM('RECEIVED','ANSWERED') NOT NULL,
+    answer LONGTEXT,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE introduce (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(100) NOT NULL,
+    subtitle VARCHAR(200),
+    summary VARCHAR(255),
+    hero_logo_keys JSON,
+    sections JSON NOT NULL,
+    version INT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE projects (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(100) NOT NULL,
+    summary VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    thumbnail_key VARCHAR(255) NOT NULL,
+    deadline_date DATE NOT NULL,
+    status ENUM('PREPARING','OPEN','CLOSED') NOT NULL,
+    category ENUM('GOODS','JOURNAL') NOT NULL,
+    pinned BIT(1) NOT NULL,
+    pinned_order INT,
+    manual_order INT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE project_images (
+    project_id BIGINT NOT NULL,
+    image_key VARCHAR(255) NOT NULL,
+    sort_order INT NOT NULL,
+    PRIMARY KEY (project_id, sort_order),
+    CONSTRAINT fk_project_images_project FOREIGN KEY (project_id) REFERENCES projects (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE project_items (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    project_id BIGINT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    summary VARCHAR(200),
+    description MEDIUMTEXT NOT NULL,
+    price INT NOT NULL,
+    sale_type ENUM('NORMAL','GROUPBUY') NOT NULL,
+    status ENUM('PREPARING','OPEN','CLOSED') NOT NULL,
+    item_type ENUM('PHYSICAL','DIGITAL_JOURNAL') NOT NULL,
+    thumbnail_key VARCHAR(255),
+    journal_file_key VARCHAR(255),
+    target_qty INT,
+    funded_qty INT,
+    stock_qty INT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_project_items_project FOREIGN KEY (project_id) REFERENCES projects (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE item_images (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    item_id BIGINT NOT NULL,
+    image_key VARCHAR(255) NOT NULL,
+    sort_order INT NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_item_images_item FOREIGN KEY (item_id) REFERENCES project_items (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE notices (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(100) NOT NULL,
+    content TEXT NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE notice_images (
+    notice_id BIGINT NOT NULL,
+    image_key VARCHAR(255),
+    sort_order INT NOT NULL,
+    PRIMARY KEY (notice_id, sort_order),
+    CONSTRAINT fk_notice_images_notice FOREIGN KEY (notice_id) REFERENCES notices (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE orders (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    order_no VARCHAR(50) NOT NULL,
+    status ENUM('PENDING_DEPOSIT','PAID','CANCELED','REFUND_REQUESTED','REFUNDED') NOT NULL,
+    total_amount INT NOT NULL,
+    shipping_fee INT NOT NULL,
+    final_amount INT NOT NULL,
+    deposit_deadline DATETIME(6) NOT NULL,
+    paid_at DATETIME(6),
+    canceled_at DATETIME(6),
+    cancel_reason VARCHAR(500),
+    refund_requested_at DATETIME(6),
+    refunded_at DATETIME(6),
+    stock_deducted_at DATETIME(6),
+    depositor_name VARCHAR(100) NOT NULL,
+    privacy_agreed BIT(1) NOT NULL,
+    privacy_agreed_at DATETIME(6) NOT NULL,
+    refund_agreed BIT(1) NOT NULL,
+    refund_agreed_at DATETIME(6) NOT NULL,
+    cancel_risk_agreed BIT(1) NOT NULL,
+    cancel_risk_agreed_at DATETIME(6) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_orders_order_no (order_no)
+) ENGINE=InnoDB;
+
+CREATE TABLE order_items (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    order_id BIGINT NOT NULL,
+    project_item_id BIGINT NOT NULL,
+    quantity INT NOT NULL,
+    unit_price INT NOT NULL,
+    line_amount INT NOT NULL,
+    item_name_snapshot VARCHAR(255) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_order_items_order FOREIGN KEY (order_id) REFERENCES orders (id),
+    CONSTRAINT fk_order_items_project_item FOREIGN KEY (project_item_id) REFERENCES project_items (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE order_auth (
+    order_id BIGINT NOT NULL,
+    lookup_id VARCHAR(50) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (order_id),
+    UNIQUE KEY uk_order_auth_lookup_id (lookup_id),
+    CONSTRAINT fk_order_auth_order FOREIGN KEY (order_id) REFERENCES orders (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE order_buyer (
+    order_id BIGINT NOT NULL,
+    buyer_type ENUM('STUDENT','STAFF','EXTERNAL') NOT NULL,
+    campus VARCHAR(50),
+    name VARCHAR(100) NOT NULL,
+    department_or_major VARCHAR(100),
+    student_no VARCHAR(50),
+    phone VARCHAR(50) NOT NULL,
+    refund_bank VARCHAR(100) NOT NULL,
+    refund_account VARCHAR(100) NOT NULL,
+    referral_source VARCHAR(100),
+    email VARCHAR(255) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (order_id),
+    CONSTRAINT fk_order_buyer_order FOREIGN KEY (order_id) REFERENCES orders (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE order_fulfillment (
+    order_id BIGINT NOT NULL,
+    method ENUM('PICKUP','DELIVERY') NOT NULL,
+    receiver_name VARCHAR(100) NOT NULL,
+    receiver_phone VARCHAR(50) NOT NULL,
+    info_confirmed BIT(1) NOT NULL,
+    postal_code VARCHAR(20),
+    address_line1 VARCHAR(255),
+    address_line2 VARCHAR(255),
+    delivery_memo VARCHAR(500),
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (order_id),
+    CONSTRAINT fk_order_fulfillment_order FOREIGN KEY (order_id) REFERENCES orders (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE order_view_tokens (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    order_id BIGINT NOT NULL,
+    token_hash VARCHAR(64) NOT NULL,
+    expires_at DATETIME(6) NOT NULL,
+    revoked_at DATETIME(6),
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_order_view_tokens_token_hash (token_hash),
+    CONSTRAINT fk_order_view_tokens_order FOREIGN KEY (order_id) REFERENCES orders (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE order_complete_pages (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    message_title VARCHAR(200) NOT NULL,
+    message_description VARCHAR(500),
+    payment_information VARCHAR(1000) NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE payouts (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(200) NOT NULL,
+    semester VARCHAR(20) NOT NULL,
+    total_income BIGINT NOT NULL,
+    total_expense BIGINT NOT NULL,
+    net_profit BIGINT NOT NULL,
+    profit_rate DOUBLE NOT NULL,
+    project_id BIGINT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_payouts_project_id (project_id),
+    CONSTRAINT fk_payouts_project FOREIGN KEY (project_id) REFERENCES projects (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE payout_items (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    payout_id BIGINT NOT NULL,
+    type ENUM('INCOME','EXPENSE') NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    amount BIGINT NOT NULL,
+    category VARCHAR(50),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_payout_items_payout FOREIGN KEY (payout_id) REFERENCES payouts (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE forms (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(200) NOT NULL,
+    `open` BIT(1) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE questions (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    label VARCHAR(255) NOT NULL,
+    description VARCHAR(255),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE form_questions (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    form_id BIGINT NOT NULL,
+    question_id BIGINT NOT NULL,
+    question_order INT NOT NULL,
+    answer_type ENUM('TEXT','FILE','SELECT') NOT NULL,
+    required BIT(1) NOT NULL,
+    section_type ENUM('BASIC','COMMON','DEPARTMENT') NOT NULL,
+    department_type ENUM('MARKETING','DESIGN','FINANCE','OPERATION'),
+    select_options VARCHAR(2000),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_form_questions_form FOREIGN KEY (form_id) REFERENCES forms (id),
+    CONSTRAINT fk_form_questions_question FOREIGN KEY (question_id) REFERENCES questions (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE form_notice (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    form_id BIGINT NOT NULL,
+    section_type ENUM('BASIC','COMMON','DEPARTMENT') NOT NULL,
+    department_type ENUM('MARKETING','DESIGN','FINANCE','OPERATION'),
+    title VARCHAR(100) NOT NULL,
+    content TEXT,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_form_notice_form FOREIGN KEY (form_id) REFERENCES forms (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE applications (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    form_id BIGINT NOT NULL,
+    student_id VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    first_department ENUM('MARKETING','DESIGN','FINANCE','OPERATION') NOT NULL,
+    second_department ENUM('MARKETING','DESIGN','FINANCE','OPERATION') NOT NULL,
+    result_status ENUM('NOT_PUBLISHED','PASS','FAIL') NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_applications_form_student (form_id, student_id),
+    CONSTRAINT fk_applications_form FOREIGN KEY (form_id) REFERENCES forms (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE answers (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    application_id BIGINT NOT NULL,
+    form_question_id BIGINT NOT NULL,
+    `value` VARCHAR(2000) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_answers_application FOREIGN KEY (application_id) REFERENCES applications (id),
+    CONSTRAINT fk_answers_form_question FOREIGN KEY (form_question_id) REFERENCES form_questions (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE sns_links (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    type ENUM('INSTAGRAM','KAKAO') NOT NULL,
+    url VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_sns_links_type (type)
+) ENGINE=InnoDB;

--- a/src/main/resources/db/migration/V2__fix_schema_drift.sql
+++ b/src/main/resources/db/migration/V2__fix_schema_drift.sql
@@ -1,0 +1,18 @@
+-- =====================================================================
+-- V2: 운영 스키마 드리프트 수정 (2026-07-11 운영 DDL 대조에서 발견)
+-- ddl-auto: update가 기존 컬럼을 변경하지 않아 누적된 엔티티↔운영 불일치.
+-- 둘 다 데이터 손실 없는 확장(widening)만 수행.
+-- =====================================================================
+
+-- 1) SectionType.BASIC이 엔티티 enum에는 있으나 운영 컬럼 enum에 없음.
+--    BASIC 값을 저장하려는 순간 운영에서 SQL 오류가 나는 잠재 버그.
+ALTER TABLE form_questions
+    MODIFY section_type ENUM('BASIC','COMMON','DEPARTMENT') NOT NULL;
+
+ALTER TABLE form_notice
+    MODIFY section_type ENUM('BASIC','COMMON','DEPARTMENT') NOT NULL;
+
+-- 2) feedbacks.answer가 TINYTEXT(최대 255바이트 ≈ 한글 85자) — 답변 저장 시 잘림 위험.
+--    엔티티(@Lob)의 기대 타입인 LONGTEXT로 확장.
+ALTER TABLE feedbacks
+    MODIFY answer LONGTEXT NULL;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,6 +10,8 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+  flyway:
+    enabled: false  # H2 단위 테스트는 create-drop 사용. MySQL 마이그레이션 검증은 Testcontainers 테스트가 담당
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
# 요약
스키마 변경을 Flyway 마이그레이션으로 관리하고, 운영을 ddl-auto validate로 전환합니다.

# 작업 내용
- [x] V1__baseline.sql — 운영 DDL 덤프(2026-07-11) 대조 완료
- [x] V2__fix_schema_drift.sql — section_type enum에 BASIC 추가, feedbacks.answer TINYTEXT→LONGTEXT
- [x] prod: ddl-auto validate + baseline-on-migrate (기존 운영 DB는 V1 미실행, V2만 적용)

# 기타 (논의하고 싶은 부분)
Testcontainers PR(#뒤이어 생성)의 CI가 V1·V2를 MySQL에서 검증한 뒤 이 PR을 병합할 것.
병합·배포 시 Flyway가 운영 DB에 V2를 자동 적용.

# 타 직군 전달 사항
recruit의 BASIC 섹션 저장이 이 PR 배포 이후부터 정상 동작합니다.