### PR TITLE
fix: 도메인 예외의 디버그 컨텍스트가 응답에 노출되는 문제 수정

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/order/exception/OrderException.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/exception/OrderException.java
@@ -8,7 +8,22 @@ public class OrderException extends DomainException {
         super(errorType);
     }
 
-    public OrderException(OrderErrorType errorType, String message) {
-        super(errorType, message);
+    public OrderException(OrderErrorType errorType, String detail) {
+        super(errorType, detail);
+    }
+
+    public OrderException(OrderErrorType errorType, String detail, String clientMessage) {
+        super(errorType, detail, clientMessage);
+    }
+
+    /**
+     * 필수 입력값 누락 — 어떤 필드가 비었는지 사용자에게 안내한다.
+     */
+    public static OrderException requiredField(OrderErrorType errorType, String fieldName) {
+        return new OrderException(
+                errorType,
+                "field=" + fieldName,
+                fieldName + "은(는) 필수입니다."
+        );
     }
 }

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/AdminOrderCompletePageService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/AdminOrderCompletePageService.java
@@ -66,10 +66,7 @@ public class AdminOrderCompletePageService {
     private String normalizeRequiredText(String value, String fieldName) {
         String normalized = trimToNull(value);
         if (normalized == null) {
-            throw new OrderException(
-                    OrderErrorType.REQUIRED_FIELD_MISSING,
-                    fieldName + "은(는) 필수입니다."
-            );
+            throw OrderException.requiredField(OrderErrorType.REQUIRED_FIELD_MISSING, fieldName);
         }
         return normalized;
     }

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/OrderCreateService.java
@@ -268,7 +268,7 @@ public class OrderCreateService {
     private String normalizeRequiredText(String value, String fieldName) {
         String normalized = trimToNull(value);
         if (normalized == null) {
-            throw new OrderException(OrderErrorType.REQUIRED_FIELD_MISSING, fieldName + "은(는) 필수입니다.");
+            throw OrderException.requiredField(OrderErrorType.REQUIRED_FIELD_MISSING, fieldName);
         }
         return normalized;
     }

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/OrderDetailQueryService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/OrderDetailQueryService.java
@@ -132,7 +132,7 @@ public class OrderDetailQueryService {
 
     private String normalizeRequiredText(String value, String fieldName) {
         if (value == null || value.isBlank()) {
-            throw new OrderException(OrderErrorType.REQUIRED_FIELD_MISSING, fieldName + "는 필수입니다.");
+            throw OrderException.requiredField(OrderErrorType.REQUIRED_FIELD_MISSING, fieldName);
         }
         return value.trim();
     }

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/OrderLookupIdService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/OrderLookupIdService.java
@@ -24,7 +24,7 @@ public class OrderLookupIdService {
     private String normalizeRequiredText(String value, String fieldName) {
         String normalized = trimToNull(value);
         if (normalized == null) {
-            throw new OrderException(OrderErrorType.LOOKUP_FIELD_REQUIRED, fieldName + "은(는) 필수입니다.");
+            throw OrderException.requiredField(OrderErrorType.LOOKUP_FIELD_REQUIRED, fieldName);
         }
         return normalized;
     }

--- a/src/main/java/com/example/cowmjucraft/global/exception/DomainException.java
+++ b/src/main/java/com/example/cowmjucraft/global/exception/DomainException.java
@@ -7,14 +7,27 @@ import lombok.Getter;
 public abstract class DomainException extends RuntimeException {
 
     private final ErrorCode errorCode;
+    private final String detail;
 
     protected DomainException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        this(errorCode, null, null);
     }
 
-    protected DomainException(ErrorCode errorCode, String message) {
-        super(message);
+    /**
+     * detail은 로그에만 남고 API 응답에는 노출되지 않는다.
+     * 내부 식별자나 디버그 컨텍스트는 이 생성자를 사용한다.
+     */
+    protected DomainException(ErrorCode errorCode, String detail) {
+        this(errorCode, detail, null);
+    }
+
+    /**
+     * clientMessage를 지정하면 응답 메시지로 사용된다.
+     * errorCode의 기본 메시지보다 구체적인 안내가 사용자에게 필요할 때만 쓴다.
+     */
+    protected DomainException(ErrorCode errorCode, String detail, String clientMessage) {
+        super(clientMessage == null ? errorCode.getMessage() : clientMessage);
         this.errorCode = errorCode;
+        this.detail = detail;
     }
 }

--- a/src/main/java/com/example/cowmjucraft/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/cowmjucraft/global/exception/GlobalExceptionHandler.java
@@ -58,9 +58,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResult<?>> handleIllegalArgument(IllegalArgumentException exception) {
+        // 예외 메시지에 내부 구현 정보가 담길 수 있으므로 로그에만 남긴다.
         log.warn("잘못된 인자값: {}", exception.getMessage(), exception);
-        String message = defaultIfBlank(exception.getMessage(), CommonErrorType.INVALID_REQUEST.getMessage());
-        return json(CommonErrorType.INVALID_REQUEST, message);
+        return json(CommonErrorType.INVALID_REQUEST, CommonErrorType.INVALID_REQUEST.getMessage());
     }
 
     @ExceptionHandler(ResponseStatusException.class)
@@ -98,7 +98,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DomainException.class)
     public ResponseEntity<ApiResult<?>> handleDomainException(DomainException exception) {
-        log.info("도메인 예외: [{}] {}", exception.getErrorCode(), exception.getMessage());
+        // detail은 내부 식별자를 담을 수 있으므로 로그에만 남기고 응답에는 노출하지 않는다.
+        log.info(
+                "도메인 예외: [{}] {}{}",
+                exception.getErrorCode(),
+                exception.getMessage(),
+                exception.getDetail() == null ? "" : " detail=" + exception.getDetail()
+        );
         return json(exception.getErrorCode(), exception.getMessage());
     }
 

--- a/src/test/java/com/example/cowmjucraft/global/exception/DomainExceptionMessageTest.java
+++ b/src/test/java/com/example/cowmjucraft/global/exception/DomainExceptionMessageTest.java
@@ -1,0 +1,46 @@
+package com.example.cowmjucraft.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.cowmjucraft.domain.order.exception.OrderErrorType;
+import com.example.cowmjucraft.domain.order.exception.OrderException;
+import org.junit.jupiter.api.Test;
+
+class DomainExceptionMessageTest {
+
+    @Test
+    void getMessage_detail만_지정_errorCode기본메시지반환() {
+        // given
+        OrderException exception = new OrderException(OrderErrorType.INSUFFICIENT_STOCK, "projectItemId=42");
+
+        // when
+        String message = exception.getMessage();
+
+        // then
+        assertThat(message).isEqualTo(OrderErrorType.INSUFFICIENT_STOCK.getMessage());
+        assertThat(message).doesNotContain("projectItemId");
+        assertThat(exception.getDetail()).isEqualTo("projectItemId=42");
+    }
+
+    @Test
+    void getMessage_detail미지정_errorCode기본메시지반환() {
+        // given
+        OrderException exception = new OrderException(OrderErrorType.ORDER_NOT_FOUND);
+
+        // when & then
+        assertThat(exception.getMessage()).isEqualTo(OrderErrorType.ORDER_NOT_FOUND.getMessage());
+        assertThat(exception.getDetail()).isNull();
+    }
+
+    @Test
+    void requiredField_필드명포함사용자메시지반환하고_detail은분리() {
+        // given
+        OrderException exception =
+                OrderException.requiredField(OrderErrorType.REQUIRED_FIELD_MISSING, "입금자명");
+
+        // when & then
+        assertThat(exception.getMessage()).isEqualTo("입금자명은(는) 필수입니다.");
+        assertThat(exception.getDetail()).isEqualTo("field=입금자명");
+        assertThat(exception.getErrorCode()).isEqualTo(OrderErrorType.REQUIRED_FIELD_MISSING);
+    }
+}

--- a/src/test/java/com/example/cowmjucraft/global/exception/GlobalExceptionHandlerResponseTest.java
+++ b/src/test/java/com/example/cowmjucraft/global/exception/GlobalExceptionHandlerResponseTest.java
@@ -1,0 +1,69 @@
+package com.example.cowmjucraft.global.exception;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.cowmjucraft.domain.order.exception.OrderErrorType;
+import com.example.cowmjucraft.domain.order.exception.OrderException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.hamcrest.Matchers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+class GlobalExceptionHandlerResponseTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ThrowingController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void 도메인예외_detail의내부식별자가응답에노출되지않는다() throws Exception {
+        mockMvc.perform(get("/test/domain-exception"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value(OrderErrorType.INSUFFICIENT_STOCK.getMessage()))
+                .andExpect(content().string(Matchers.not(Matchers.containsString("projectItemId"))));
+    }
+
+    @Test
+    void 필수값누락_필드명안내는응답에유지된다() throws Exception {
+        mockMvc.perform(get("/test/required-field"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("입금자명은(는) 필수입니다."));
+    }
+
+    @Test
+    void IllegalArgumentException_예외메시지가응답에노출되지않는다() throws Exception {
+        mockMvc.perform(get("/test/illegal-argument"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(Matchers.not(Matchers.containsString("internal detail"))));
+    }
+
+    @RestController
+    static class ThrowingController {
+
+        @GetMapping("/test/domain-exception")
+        void domainException() {
+            throw new OrderException(OrderErrorType.INSUFFICIENT_STOCK, "projectItemId=42");
+        }
+
+        @GetMapping("/test/required-field")
+        void requiredField() {
+            throw OrderException.requiredField(OrderErrorType.REQUIRED_FIELD_MISSING, "입금자명");
+        }
+
+        @GetMapping("/test/illegal-argument")
+        void illegalArgument() {
+            throw new IllegalArgumentException("internal detail leaked");
+        }
+    }
+}


### PR DESCRIPTION
# 요약

`GlobalExceptionHandler`가 `exception.getMessage()`를 응답 본문에 그대로 넣는데, 서비스는 그 자리에 디버그 컨텍스트를 넘기고 있었습니다.

```java
throw new OrderException(OrderErrorType.INSUFFICIENT_STOCK, "projectItemId=" + item.getId());
```

**이전**
```json
{ "code": "INSUFFICIENT_STOCK", "message": "projectItemId=42" }
```

**이후**
```json
{ "code": "INSUFFICIENT_STOCK", "message": "재고가 부족하여 주문할 수 없습니다." }
```

프런트가 `client.ts`에서 이 `message`를 그대로 토스트에 띄우고 있어(`OrderPage.tsx`, `OrderLookupPage.tsx`), 사용자가 보던 문구가 바로 개선됩니다. 내부 PK 노출도 함께 해소됩니다.

# 작업 내용

- [x] `DomainException`에 `detail`(로그 전용) / `clientMessage`(응답) 분리
  - `super()`에는 항상 사용자용 메시지를 넣도록 변경
  - **2인자 생성자 시그니처는 그대로** — 디버그 컨텍스트를 넘기던 호출부 40여 곳은 수정 불필요
- [x] `GlobalExceptionHandler`: `detail`은 로그에만 기록, 응답에는 미노출
- [x] `handleIllegalArgument`: 예외 메시지 대신 고정 메시지 반환
- [x] `OrderException.requiredField()` 팩토리 추가 — 필드명 안내가 필요한 4곳은 사용자 메시지를 명시적으로 유지
- [x] 테스트 6개 추가 (`DomainExceptionMessageTest` 3, `GlobalExceptionHandlerResponseTest` 3)

# 기타 (논의하고 싶은 부분)

**호출부 분류 기준**

2인자 호출을 전수 조사해 두 종류로 나눴습니다.

| 분류 | 처리 | 예시 |
|---|---|---|
| 한글 사용자 안내 (4곳) | `clientMessage`로 유지 | `"입금자명은(는) 필수입니다."` |
| 디버그 컨텍스트 (나머지 전부) | `detail`로 이동 | `"orderId=123"`, `"itemType must be DIGITAL_JOURNAL"` |

관리자용 검증 메시지(`"files[0] is null"`, `"duplicate pinnedOrder: 3"`)도 전부 영문 디버그 문자열이라 `detail`로 보냈습니다. `ErrorType` 기본 메시지로 충분하고 상세는 로그에서 확인합니다. 이 판단에 이견 있으면 말씀해주세요.

**테스트**: 26개 전부 통과 (기존 20 + 신규 6), 회귀 없음

# 타 직군 전달 사항

프런트에서 별도 대응은 필요 없습니다. 서버 `message`를 그대로 쓰는 현재 구조에서 문구만 정상화됩니다.

다만 앞으로 `code` 필드 기반으로 프런트가 자체 문구를 매핑하는 구조를 논의해볼 만합니다 — 지금은 서버 메시지에 전적으로 의존합니다.