### PR TITLE
feat: 인증·조회 엔드포인트 보호 강화 (요청 제한 / 타이밍 / 비밀번호 정책)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 
+	// 인증 엔드포인트 요청 제한 (토큰 버킷) — 전이 의존성 없는 단일 jar
+	implementation 'com.bucket4j:bucket4j-core:8.10.1'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/example/cowmjucraft/domain/accounts/admin/auth/service/AdminAuthService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/accounts/admin/auth/service/AdminAuthService.java
@@ -9,7 +9,7 @@ import com.example.cowmjucraft.domain.accounts.Role;
 import com.example.cowmjucraft.domain.accounts.exception.AccountErrorType;
 import com.example.cowmjucraft.domain.accounts.exception.AccountException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import com.example.cowmjucraft.global.security.CredentialMatcher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,15 +19,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminAuthService {
 
     private final AdminRepository adminRepository;
-    private final PasswordEncoder passwordEncoder;
+    private final CredentialMatcher credentialMatcher;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
 
     public LoginResult login(AdminLoginRequestDto request) {
-        Admin admin = adminRepository.findByLoginId(request.userId())
-                .orElseThrow(() -> new AccountException(AccountErrorType.INVALID_CREDENTIALS));
+        // 계정이 없어도 해시 연산을 수행해 응답 시간으로 계정 존재 여부가 드러나지 않게 한다.
+        Admin admin = adminRepository.findByLoginId(request.userId()).orElse(null);
+        String storedHash = admin == null ? null : admin.getPassword();
 
-        if (!passwordEncoder.matches(request.password(), admin.getPassword())) {
+        if (!credentialMatcher.matches(request.password(), storedHash)) {
             throw new AccountException(AccountErrorType.INVALID_CREDENTIALS);
         }
 

--- a/src/main/java/com/example/cowmjucraft/domain/order/exception/OrderErrorType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/exception/OrderErrorType.java
@@ -33,6 +33,7 @@ public enum OrderErrorType implements ErrorCode {
     QUANTITY_MUST_BE_POSITIVE(400, "주문 수량은 1개 이상이어야 합니다."),
     SALE_TYPE_NOT_ORDERABLE(400, "주문할 수 없는 판매 유형입니다."),
     DELIVERY_ADDRESS_REQUIRED(400, "배송 주문은 우편번호와 기본 주소가 필수입니다."),
+    WEAK_PASSWORD(422, "조회 비밀번호는 8자 이상이며 영문과 숫자를 모두 포함해야 합니다."),
     REQUIRED_FIELD_MISSING(400, "필수 입력값이 누락되었습니다."),
     PRIVACY_AGREEMENT_REQUIRED(400, "개인정보 수집 및 이용 동의가 필요합니다."),
     REFUND_AGREEMENT_REQUIRED(400, "환불 정책 동의가 필요합니다."),

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/OrderCreateService.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import com.example.cowmjucraft.global.security.PasswordPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,6 +53,7 @@ public class OrderCreateService {
     private final PasswordEncoder passwordEncoder;
     private final OrderViewTokenService orderViewTokenService;
     private final MailOutboxService mailOutboxService;
+    private final PasswordPolicy passwordPolicy;
 
     @Transactional
     public OrderCreateResponseDto createOrder(OrderCreateRequestDto request) {
@@ -60,6 +62,10 @@ public class OrderCreateService {
         String depositorName = normalizeRequiredText(request.depositorName(), "입금자명");
         String lookupId = normalizeRequiredText(request.lookupId(), "조회 아이디");
         String password = normalizeRequiredText(request.password(), "조회 비밀번호");
+
+        if (!passwordPolicy.isValid(password)) {
+            throw new OrderException(OrderErrorType.WEAK_PASSWORD);
+        }
 
         if (orderAuthRepository.existsByLookupId(lookupId)) {
             throw new OrderException(OrderErrorType.DUPLICATED_LOOKUP_ID);

--- a/src/main/java/com/example/cowmjucraft/domain/order/service/OrderDetailQueryService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/order/service/OrderDetailQueryService.java
@@ -9,7 +9,7 @@ import com.example.cowmjucraft.domain.order.repository.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import com.example.cowmjucraft.global.security.CredentialMatcher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +24,7 @@ public class OrderDetailQueryService {
     private final OrderFulfillmentRepository orderFulfillmentRepository;
     private final OrderRepository orderRepository;
     private final OrderViewTokenService orderViewTokenService;
-    private final PasswordEncoder passwordEncoder;
+    private final CredentialMatcher credentialMatcher;
     private final OrderCompletePageRepository orderCompletePageRepository;
 
     @Transactional(readOnly = true)
@@ -32,10 +32,11 @@ public class OrderDetailQueryService {
         String normalizedLookupId = normalizeRequiredText(lookupId, "lookupId");
         String normalizedPassword = normalizeRequiredText(password, "password");
 
-        OrderAuth orderAuth = orderAuthRepository.findByLookupId(normalizedLookupId)
-                .orElseThrow(this::invalidLookupCredentials);
+        // 조회 아이디가 없어도 해시 연산을 수행해 응답 시간으로 존재 여부가 드러나지 않게 한다.
+        OrderAuth orderAuth = orderAuthRepository.findByLookupId(normalizedLookupId).orElse(null);
+        String storedHash = orderAuth == null ? null : orderAuth.getPasswordHash();
 
-        if (!passwordEncoder.matches(normalizedPassword, orderAuth.getPasswordHash())) {
+        if (!credentialMatcher.matches(normalizedPassword, storedHash)) {
             throw invalidLookupCredentials();
         }
 

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/exception/RecruitErrorType.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/exception/RecruitErrorType.java
@@ -37,6 +37,7 @@ public enum RecruitErrorType implements ErrorCode {
     CANNOT_DELETE_FORM_WITH_APPLICATIONS(400,"지원서가 존재하는 폼은 삭제할 수 없습니다"),
 
     RECRUITMENT_CLOSED(409, "모집이 마감되었습니다."),
+    WEAK_PASSWORD(422, "비밀번호는 8자 이상이며 영문과 숫자를 모두 포함해야 합니다."),
     DUPLICATE_STUDENT_ID(409, "이미 제출된 학번입니다."),
     DUPLICATE_QUESTION_ORDER(409, "문항 순서가 중복되었습니다.");
 

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
@@ -10,6 +10,7 @@ import com.example.cowmjucraft.domain.recruit.exception.RecruitException;
 import com.example.cowmjucraft.domain.recruit.repository.*;
 import com.example.cowmjucraft.global.cloud.S3PresignFacade;
 import com.example.cowmjucraft.global.security.CredentialMatcher;
+import com.example.cowmjucraft.global.security.PasswordPolicy;
 import com.example.cowmjucraft.domain.recruit.exception.RecruitErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,6 +30,7 @@ public class ApplicationService {
     private final AnswerRepository answerRepository;
     private final PasswordEncoder passwordEncoder;
     private final CredentialMatcher credentialMatcher;
+    private final PasswordPolicy passwordPolicy;
     private final QuestionRepository questionRepository;
     private final S3PresignFacade s3PresignFacade;
     private final FormNoticeRepository formNoticeRepository;
@@ -129,6 +131,10 @@ public class ApplicationService {
             if (formQuestion.isRequired() && e.getValue() == null) {
                 throw new RecruitException(RecruitErrorType.REQUIRED_ANSWER_MISSING);
             }
+        }
+
+        if (!passwordPolicy.isValid(request.getPassword())) {
+            throw new RecruitException(RecruitErrorType.WEAK_PASSWORD);
         }
 
         String passwordHash = passwordEncoder.encode(request.getPassword());

--- a/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/recruit/service/client/ApplicationService.java
@@ -9,6 +9,7 @@ import com.example.cowmjucraft.domain.recruit.entity.*;
 import com.example.cowmjucraft.domain.recruit.exception.RecruitException;
 import com.example.cowmjucraft.domain.recruit.repository.*;
 import com.example.cowmjucraft.global.cloud.S3PresignFacade;
+import com.example.cowmjucraft.global.security.CredentialMatcher;
 import com.example.cowmjucraft.domain.recruit.exception.RecruitErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,6 +28,7 @@ public class ApplicationService {
     private final FormQuestionRepository formQuestionRepository;
     private final AnswerRepository answerRepository;
     private final PasswordEncoder passwordEncoder;
+    private final CredentialMatcher credentialMatcher;
     private final QuestionRepository questionRepository;
     private final S3PresignFacade s3PresignFacade;
     private final FormNoticeRepository formNoticeRepository;
@@ -158,10 +160,12 @@ public class ApplicationService {
 
         Form form = findReadableForm(request.getFormId());
 
+        // 지원서가 없어도 해시 연산을 수행해 응답 시간으로 존재 여부가 드러나지 않게 한다.
         Application application = applicationRepository.findByFormAndStudentId(form, request.getStudentId())
-                .orElseThrow(() -> new RecruitException(RecruitErrorType.APPLICATION_NOT_FOUND));
+                .orElse(null);
+        String storedHash = application == null ? null : application.getPasswordHash();
 
-        if (!passwordEncoder.matches(request.getPassword(), application.getPasswordHash())) {
+        if (!credentialMatcher.matches(request.getPassword(), storedHash)) {
             throw new RecruitException(RecruitErrorType.INVALID_CREDENTIALS);
         }
 
@@ -260,10 +264,12 @@ public class ApplicationService {
 
         Form form = findWritableForm(request.getFormId());
 
+        // 지원서가 없어도 해시 연산을 수행해 응답 시간으로 존재 여부가 드러나지 않게 한다.
         Application application = applicationRepository.findByFormAndStudentId(form, request.getStudentId())
-                .orElseThrow(() -> new RecruitException(RecruitErrorType.APPLICATION_NOT_FOUND));
+                .orElse(null);
+        String storedHash = application == null ? null : application.getPasswordHash();
 
-        if (!passwordEncoder.matches(request.getPassword(), application.getPasswordHash())) {
+        if (!credentialMatcher.matches(request.getPassword(), storedHash)) {
             throw new RecruitException(RecruitErrorType.INVALID_CREDENTIALS);
         }
 
@@ -376,10 +382,12 @@ public class ApplicationService {
 
         Form form = findReadableForm(request.getFormId());
 
+        // 지원서가 없어도 해시 연산을 수행해 응답 시간으로 존재 여부가 드러나지 않게 한다.
         Application application = applicationRepository.findByFormAndStudentId(form, request.getStudentId())
-                .orElseThrow(() -> new RecruitException(RecruitErrorType.APPLICATION_NOT_FOUND));
+                .orElse(null);
+        String storedHash = application == null ? null : application.getPasswordHash();
 
-        if (!passwordEncoder.matches(request.getPassword(), application.getPasswordHash())) {
+        if (!credentialMatcher.matches(request.getPassword(), storedHash)) {
             throw new RecruitException(RecruitErrorType.INVALID_CREDENTIALS);
         }
 

--- a/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitConfig.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitConfig.java
@@ -1,0 +1,29 @@
+package com.example.cowmjucraft.global.config.ratelimit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+public class RateLimitConfig {
+
+    /**
+     * 인증 처리보다 먼저 실행되도록 Security 필터 체인 앞에 등록한다.
+     * 제한에 걸린 요청은 비밀번호 검증까지 가지 않는다.
+     */
+    @Bean
+    public FilterRegistrationBean<RateLimitFilter> rateLimitFilterRegistration(
+            RateLimitProperties properties,
+            RateLimitService rateLimitService,
+            ObjectMapper objectMapper
+    ) {
+        FilterRegistrationBean<RateLimitFilter> registration = new FilterRegistrationBean<>(
+                new RateLimitFilter(properties, rateLimitService, objectMapper)
+        );
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 100);
+        registration.addUrlPatterns("/api/*");
+        return registration;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitFilter.java
@@ -1,0 +1,96 @@
+package com.example.cowmjucraft.global.config.ratelimit;
+
+import com.example.cowmjucraft.global.response.ApiResult;
+import com.example.cowmjucraft.global.response.type.CommonErrorType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 인증·조회 엔드포인트의 요청 횟수를 제한한다.
+ *
+ * <p>대부분의 규칙은 <b>실패한 요청만</b> 센다. 공유 IP(캠퍼스 와이파이, 캐리어 NAT)
+ * 환경에서 정상 사용자가 서로의 한도를 잠식하지 않게 하기 위해서다.
+ * 정상 사용자는 비밀번호를 맞히므로 카운터를 거의 소모하지 않는다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final RateLimitProperties properties;
+    private final RateLimitService rateLimitService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (!properties.isEnabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        RateLimitRule rule = resolveRule(request);
+        if (rule == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // getRemoteAddr()는 server.forward-headers-strategy 설정에 의해
+        // X-Forwarded-For의 실제 클라이언트 IP로 해석된다.
+        String clientKey = request.getRemoteAddr();
+
+        if (!rateLimitService.hasCapacity(rule, clientKey)) {
+            log.warn("요청 제한 초과: rule={}, path={}", rule.getKey(), request.getRequestURI());
+            writeTooManyRequests(response, rule);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+
+        if (shouldConsume(rule, response.getStatus())) {
+            rateLimitService.consume(rule, clientKey);
+        }
+    }
+
+    private RateLimitRule resolveRule(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return Arrays.stream(RateLimitRule.values())
+                .filter(rule -> rule.matches(path))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * 실패만 세는 규칙에서는 인증 실패(401)와 대상 없음(404)만 카운트한다.
+     * 400·422 같은 입력 형식 오류는 자격증명 추측이 아니므로 세지 않는다.
+     */
+    private boolean shouldConsume(RateLimitRule rule, int status) {
+        if (!rule.isCountOnlyFailures()) {
+            return true;
+        }
+        return status == 401 || status == 404;
+    }
+
+    private void writeTooManyRequests(HttpServletResponse response, RateLimitRule rule) throws IOException {
+        response.setStatus(CommonErrorType.TOO_MANY_REQUESTS.getHttpStatusCode());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(rateLimitService.retryAfterSeconds(rule)));
+        objectMapper.writeValue(
+                response.getWriter(),
+                ApiResult.error(CommonErrorType.TOO_MANY_REQUESTS)
+        );
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitProperties.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitProperties.java
@@ -1,0 +1,44 @@
+package com.example.cowmjucraft.global.config.ratelimit;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@Component
+@ConfigurationProperties(prefix = "app.rate-limit")
+public class RateLimitProperties {
+
+    /** 요청 제한 전체 on/off. 장애 시 재배포 없이 끌 수 있도록 둔다. */
+    private boolean enabled = true;
+
+    /** 사용하지 않는 버킷을 정리하기까지의 유휴 시간. */
+    private Duration idleEviction = Duration.ofMinutes(30);
+
+    /** {@link RateLimitRule#getKey()} → 임계값 */
+    private Map<String, Limit> rules = new LinkedHashMap<>();
+
+    public Limit limitFor(RateLimitRule rule) {
+        return rules.get(rule.getKey());
+    }
+
+    @Getter
+    @Setter
+    public static class Limit {
+
+        @Min(value = 1, message = "capacity must be >= 1")
+        private int capacity;
+
+        @NotNull(message = "window must not be null")
+        private Duration window;
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitRule.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitRule.java
@@ -1,0 +1,42 @@
+package com.example.cowmjucraft.global.config.ratelimit;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 요청 제한 대상 엔드포인트.
+ *
+ * <p>경로와 카운트 방식은 구조적 성격이라 코드에 고정하고,
+ * 임계값(capacity/window)만 {@link RateLimitProperties}로 조정한다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum RateLimitRule {
+
+    /** 관리자 로그인 — 실패한 시도만 센다. */
+    ADMIN_LOGIN("admin-login", List.of("/api/admin/login"), true),
+
+    /** 관리자 토큰 재발급 — 실패한 시도만 센다. */
+    ADMIN_REFRESH("admin-refresh", List.of("/api/admin/refresh"), true),
+
+    /** 비회원 주문 조회 — 실패한 시도만 센다. */
+    ORDER_LOOKUP("order-lookup", List.of("/api/orders/lookup"), true),
+
+    /** 지원서·결과 조회 — 실패한 시도만 센다. */
+    APPLICATION_READ("application-read", List.of("/api/application/read", "/api/result"), true),
+
+    /**
+     * 조회 아이디 중복 확인 — 성공 응답 자체가 "해당 ID 존재" 정보를 노출하므로
+     * 성공·실패를 가리지 않고 모든 요청을 센다.
+     */
+    LOOKUP_ID_AVAILABILITY("lookup-id-availability", List.of("/api/orders/lookup-id/availability"), false);
+
+    private final String key;
+    private final List<String> paths;
+    private final boolean countOnlyFailures;
+
+    public boolean matches(String requestPath) {
+        return paths.contains(requestPath);
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitService.java
+++ b/src/main/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitService.java
@@ -1,0 +1,109 @@
+package com.example.cowmjucraft.global.config.ratelimit;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * 규칙 + 클라이언트 키 단위로 토큰 버킷을 관리한다.
+ *
+ * <p>단일 인스턴스 전제의 인메모리 구현이다. 스케일아웃 시에는 인스턴스별로
+ * 카운터가 분리되므로 공유 저장소(Redis) 기반으로 교체해야 한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RateLimitService {
+
+    private final RateLimitProperties properties;
+    private final Map<String, Entry> buckets = new ConcurrentHashMap<>();
+
+    /** 토큰을 소모하지 않고 남은 여유가 있는지만 확인한다. */
+    public boolean hasCapacity(RateLimitRule rule, String clientKey) {
+        RateLimitProperties.Limit limit = properties.limitFor(rule);
+        if (limit == null) {
+            return true;
+        }
+        return entry(rule, clientKey, limit).bucket().getAvailableTokens() > 0;
+    }
+
+    /** 토큰 하나를 소모한다. 남은 토큰이 없으면 아무 일도 하지 않는다. */
+    public void consume(RateLimitRule rule, String clientKey) {
+        RateLimitProperties.Limit limit = properties.limitFor(rule);
+        if (limit == null) {
+            return;
+        }
+        entry(rule, clientKey, limit).bucket().tryConsume(1);
+    }
+
+    /** 제한에 걸렸을 때 클라이언트에게 안내할 재시도 대기 시간(초). */
+    public long retryAfterSeconds(RateLimitRule rule) {
+        RateLimitProperties.Limit limit = properties.limitFor(rule);
+        return limit == null ? 60L : Math.max(1L, limit.getWindow().toSeconds());
+    }
+
+    private Entry entry(RateLimitRule rule, String clientKey, RateLimitProperties.Limit limit) {
+        Entry entry = buckets.computeIfAbsent(
+                rule.getKey() + '|' + clientKey,
+                ignored -> new Entry(newBucket(limit))
+        );
+        entry.touch();
+        return entry;
+    }
+
+    private Bucket newBucket(RateLimitProperties.Limit limit) {
+        return Bucket.builder()
+                .addLimit(Bandwidth.builder()
+                        .capacity(limit.getCapacity())
+                        .refillGreedy(limit.getCapacity(), limit.getWindow())
+                        .build())
+                .build();
+    }
+
+    /**
+     * 유휴 버킷을 정리한다. 클라이언트 키가 IP 단위라 방치하면 메모리가 계속 늘어난다.
+     */
+    @Scheduled(fixedDelayString = "${app.rate-limit.eviction-interval-ms:600000}")
+    public void evictIdleBuckets() {
+        Duration idleEviction = properties.getIdleEviction();
+        Instant threshold = Instant.now().minus(idleEviction);
+
+        int before = buckets.size();
+        buckets.entrySet().removeIf(entry -> entry.getValue().lastAccessedAt().isBefore(threshold));
+        int removed = before - buckets.size();
+
+        if (removed > 0) {
+            log.debug("요청 제한 버킷 정리: 제거={}, 잔여={}", removed, buckets.size());
+        }
+    }
+
+    private static final class Entry {
+
+        private final Bucket bucket;
+        private volatile Instant lastAccessedAt;
+
+        private Entry(Bucket bucket) {
+            this.bucket = bucket;
+            this.lastAccessedAt = Instant.now();
+        }
+
+        private Bucket bucket() {
+            return bucket;
+        }
+
+        private Instant lastAccessedAt() {
+            return lastAccessedAt;
+        }
+
+        private void touch() {
+            this.lastAccessedAt = Instant.now();
+        }
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/security/CredentialMatcher.java
+++ b/src/main/java/com/example/cowmjucraft/global/security/CredentialMatcher.java
@@ -1,0 +1,40 @@
+package com.example.cowmjucraft.global.security;
+
+import java.util.UUID;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * 자격증명 대조 시 응답 시간을 균일하게 유지한다.
+ *
+ * <p>대상이 없을 때 즉시 실패하면 해시 연산에 걸리는 시간만큼 차이가 생겨,
+ * 응답 시간만으로 계정·주문·지원서의 존재 여부를 알아낼 수 있다.
+ * 저장된 해시가 없어도 더미 해시로 같은 연산을 수행해 시간 차이를 없앤다.
+ */
+@Component
+public class CredentialMatcher {
+
+    private final PasswordEncoder passwordEncoder;
+    private final String dummyHash;
+
+    public CredentialMatcher(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+        this.dummyHash = passwordEncoder.encode(UUID.randomUUID().toString());
+    }
+
+    /**
+     * @param storedHash 저장된 해시. 대상이 없으면 {@code null}을 넘긴다.
+     * @return 일치 여부. {@code storedHash}가 {@code null}이면 항상 {@code false}
+     */
+    public boolean matches(String rawPassword, String storedHash) {
+        if (rawPassword == null) {
+            passwordEncoder.matches("", dummyHash);
+            return false;
+        }
+        if (storedHash == null) {
+            passwordEncoder.matches(rawPassword, dummyHash);
+            return false;
+        }
+        return passwordEncoder.matches(rawPassword, storedHash);
+    }
+}

--- a/src/main/java/com/example/cowmjucraft/global/security/PasswordPolicy.java
+++ b/src/main/java/com/example/cowmjucraft/global/security/PasswordPolicy.java
@@ -1,0 +1,39 @@
+package com.example.cowmjucraft.global.security;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.stereotype.Component;
+
+/**
+ * 비회원 조회용 비밀번호(주문·지원서)의 최소 강도 정책.
+ *
+ * <p>요청 제한만으로는 `1234` 같은 비밀번호를 막지 못한다.
+ * 도메인별 예외 타입이 달라 검증 결과만 돌려주고 예외는 호출부가 던진다.
+ *
+ * <p>신규 생성분에만 적용된다. 기존에 저장된 비밀번호의 조회는 영향받지 않는다.
+ */
+@Component
+public class PasswordPolicy {
+
+    private static final int MIN_LENGTH = 8;
+
+    /** bcrypt는 72바이트를 넘는 입력을 잘라내므로 그 이상은 받지 않는다. */
+    private static final int MAX_BYTES = 72;
+
+    public boolean isValid(String rawPassword) {
+        if (rawPassword == null || rawPassword.length() < MIN_LENGTH) {
+            return false;
+        }
+        if (rawPassword.getBytes(StandardCharsets.UTF_8).length > MAX_BYTES) {
+            return false;
+        }
+        return containsLetter(rawPassword) && containsDigit(rawPassword);
+    }
+
+    private boolean containsLetter(String value) {
+        return value.chars().anyMatch(Character::isLetter);
+    }
+
+    private boolean containsDigit(String value) {
+        return value.chars().anyMatch(Character::isDigit);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
 
 server:
   port: 8080
+  # 리버스 프록시(Coolify/Traefik) 뒤에서 실제 클라이언트 IP를 인식하기 위해 필요하다.
+  # 이 설정이 없으면 getRemoteAddr()가 프록시 IP만 반환해 IP 기반 로직이 모두 무력화된다.
+  # 프록시가 없는 환경에서는 X-Forwarded-* 헤더가 오지 않으므로 동작에 영향이 없다.
+  forward-headers-strategy: framework
 
 aws:
   region: ${AWS_REGION:ap-northeast-2}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,29 @@ management:
     health:
       show-details: never
 
+app:
+  # 인증·조회 엔드포인트 요청 제한. 값은 재배포 없이 환경변수로 조정한다.
+  # 단일 인스턴스 전제의 인메모리 구현 — 스케일아웃 시 Redis 기반으로 교체해야 한다.
+  rate-limit:
+    enabled: ${RATE_LIMIT_ENABLED:true}
+    idle-eviction: ${RATE_LIMIT_IDLE_EVICTION:PT30M}
+    rules:
+      admin-login:
+        capacity: ${RATE_LIMIT_ADMIN_LOGIN_CAPACITY:10}
+        window: ${RATE_LIMIT_ADMIN_LOGIN_WINDOW:PT10M}
+      admin-refresh:
+        capacity: ${RATE_LIMIT_ADMIN_REFRESH_CAPACITY:20}
+        window: ${RATE_LIMIT_ADMIN_REFRESH_WINDOW:PT1M}
+      order-lookup:
+        capacity: ${RATE_LIMIT_ORDER_LOOKUP_CAPACITY:10}
+        window: ${RATE_LIMIT_ORDER_LOOKUP_WINDOW:PT10M}
+      application-read:
+        capacity: ${RATE_LIMIT_APPLICATION_READ_CAPACITY:10}
+        window: ${RATE_LIMIT_APPLICATION_READ_WINDOW:PT10M}
+      lookup-id-availability:
+        capacity: ${RATE_LIMIT_LOOKUP_ID_CAPACITY:20}
+        window: ${RATE_LIMIT_LOOKUP_ID_WINDOW:PT1M}
+
 mail:
   outbox:
     enabled: ${MAIL_OUTBOX_ENABLED:true}

--- a/src/test/java/com/example/cowmjucraft/domain/order/service/OrderCreateServiceTest.java
+++ b/src/test/java/com/example/cowmjucraft/domain/order/service/OrderCreateServiceTest.java
@@ -12,11 +12,13 @@ import com.example.cowmjucraft.domain.order.dto.request.OrderCreateRequestDto;
 import com.example.cowmjucraft.domain.order.entity.Order;
 import com.example.cowmjucraft.domain.order.entity.OrderBuyerType;
 import com.example.cowmjucraft.domain.order.entity.OrderFulfillmentMethod;
+import com.example.cowmjucraft.domain.order.exception.OrderException;
 import com.example.cowmjucraft.domain.order.repository.OrderAuthRepository;
 import com.example.cowmjucraft.domain.order.repository.OrderBuyerRepository;
 import com.example.cowmjucraft.domain.order.repository.OrderFulfillmentRepository;
 import com.example.cowmjucraft.domain.order.repository.OrderItemRepository;
 import com.example.cowmjucraft.domain.order.repository.OrderRepository;
+import com.example.cowmjucraft.global.security.PasswordPolicy;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -66,7 +69,8 @@ class OrderCreateServiceTest {
                 projectItemRepository,
                 passwordEncoder,
                 orderViewTokenService,
-                mailOutboxService
+                mailOutboxService,
+                new PasswordPolicy()
         );
     }
 
@@ -112,6 +116,16 @@ class OrderCreateServiceTest {
         verify(orderItemRepository).saveAll(any());
     }
 
+    @Test
+    void createOrder_비밀번호가정책미달_OrderException발생() {
+        // given
+        OrderCreateRequestDto weakPasswordRequest = request(1, "1234");
+
+        // when & then
+        assertThatThrownBy(() -> orderCreateService.createOrder(weakPasswordRequest))
+                .isInstanceOf(OrderException.class);
+    }
+
     private ProjectItem groupbuyItem(Long id, int targetQty, int fundedQty) {
         ProjectItem item = new ProjectItem(
                 null,
@@ -133,9 +147,13 @@ class OrderCreateServiceTest {
     }
 
     private OrderCreateRequestDto request(int quantity) {
+        return request(quantity, "Pa$$w0rd!");
+    }
+
+    private OrderCreateRequestDto request(int quantity, String password) {
         return new OrderCreateRequestDto(
                 "guest-mju-001",
-                "Pa$$w0rd!",
+                password,
                 "홍길동",
                 true,
                 true,

--- a/src/test/java/com/example/cowmjucraft/global/config/ForwardedHeaderTest.java
+++ b/src/test/java/com/example/cowmjucraft/global/config/ForwardedHeaderTest.java
@@ -1,0 +1,84 @@
+package com.example.cowmjucraft.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 리버스 프록시 뒤에서 실제 클라이언트 IP가 인식되는지 검증한다.
+ * IP 기반 요청 제한이 이 동작에 의존한다.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "server.forward-headers-strategy=framework"
+)
+class ForwardedHeaderTest {
+
+    private static final String FORWARDED_CLIENT_IP = "203.0.113.7";
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    void XForwardedFor헤더가있으면_실제클라이언트IP를반환한다() throws Exception {
+        // when
+        String remoteAddr = callRemoteAddr(FORWARDED_CLIENT_IP);
+
+        // then
+        assertThat(remoteAddr).isEqualTo(FORWARDED_CLIENT_IP);
+    }
+
+    @Test
+    void XForwardedFor헤더가없으면_직접연결IP를반환한다() throws Exception {
+        // when
+        String remoteAddr = callRemoteAddr(null);
+
+        // then
+        assertThat(remoteAddr).isNotBlank();
+        assertThat(remoteAddr).isNotEqualTo(FORWARDED_CLIENT_IP);
+    }
+
+    private String callRemoteAddr(String forwardedFor) throws IOException, InterruptedException {
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/test/remote-addr"))
+                .GET();
+
+        if (forwardedFor != null) {
+            builder.header("X-Forwarded-For", forwardedFor);
+        }
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            return client.send(builder.build(), HttpResponse.BodyHandlers.ofString()).body();
+        }
+    }
+
+    @TestConfiguration
+    static class RemoteAddrControllerConfig {
+
+        @Bean
+        RemoteAddrController remoteAddrController() {
+            return new RemoteAddrController();
+        }
+    }
+
+    @RestController
+    static class RemoteAddrController {
+
+        @GetMapping("/test/remote-addr")
+        String remoteAddr(HttpServletRequest request) {
+            return request.getRemoteAddr();
+        }
+    }
+}

--- a/src/test/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitFilterTest.java
+++ b/src/test/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitFilterTest.java
@@ -1,0 +1,133 @@
+package com.example.cowmjucraft.global.config.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RateLimitFilterTest {
+
+    private static final String CLIENT_IP = "203.0.113.7";
+
+    private RateLimitProperties properties;
+    private RateLimitFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        properties = new RateLimitProperties();
+        properties.setRules(Map.of(
+                RateLimitRule.ADMIN_LOGIN.getKey(), limit(3, Duration.ofMinutes(10)),
+                RateLimitRule.LOOKUP_ID_AVAILABILITY.getKey(), limit(3, Duration.ofMinutes(1))
+        ));
+        filter = new RateLimitFilter(properties, new RateLimitService(properties), new ObjectMapper());
+    }
+
+    @Test
+    void doFilter_로그인성공반복_제한되지않음() throws Exception {
+        // given — 실패만 세는 규칙이므로 성공은 카운터를 쓰지 않는다
+        FilterChain success = (req, res) -> ((MockHttpServletResponse) res).setStatus(200);
+
+        // when
+        for (int i = 0; i < 10; i++) {
+            call("/api/admin/login", success);
+        }
+
+        // then
+        assertThat(call("/api/admin/login", success).getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void doFilter_로그인실패반복_한도초과시429() throws Exception {
+        // given
+        FilterChain unauthorized = (req, res) -> ((MockHttpServletResponse) res).setStatus(401);
+
+        // when — capacity 3 소진
+        for (int i = 0; i < 3; i++) {
+            assertThat(call("/api/admin/login", unauthorized).getStatus()).isEqualTo(401);
+        }
+
+        // then
+        MockHttpServletResponse blocked = call("/api/admin/login", unauthorized);
+        assertThat(blocked.getStatus()).isEqualTo(429);
+        assertThat(blocked.getHeader("Retry-After")).isEqualTo("600");
+        assertThat(blocked.getContentAsString()).contains("요청 횟수가 초과되었습니다.");
+    }
+
+    @Test
+    void doFilter_입력형식오류는_카운트하지않음() throws Exception {
+        // given — 400은 자격증명 추측이 아니다
+        FilterChain badRequest = (req, res) -> ((MockHttpServletResponse) res).setStatus(400);
+
+        // when
+        for (int i = 0; i < 10; i++) {
+            call("/api/admin/login", badRequest);
+        }
+
+        // then
+        assertThat(call("/api/admin/login", badRequest).getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void doFilter_중복확인은_성공응답도카운트() throws Exception {
+        // given — 성공 응답 자체가 ID 존재 여부를 노출하므로 전부 센다
+        FilterChain success = (req, res) -> ((MockHttpServletResponse) res).setStatus(200);
+
+        // when
+        for (int i = 0; i < 3; i++) {
+            assertThat(call("/api/orders/lookup-id/availability", success).getStatus()).isEqualTo(200);
+        }
+
+        // then
+        assertThat(call("/api/orders/lookup-id/availability", success).getStatus()).isEqualTo(429);
+    }
+
+    @Test
+    void doFilter_제한대상아닌경로_통과() throws Exception {
+        // given
+        FilterChain unauthorized = (req, res) -> ((MockHttpServletResponse) res).setStatus(401);
+
+        // when — 401을 반복해도 제한 대상이 아니면 통과한다
+        for (int i = 0; i < 20; i++) {
+            call("/api/projects", unauthorized);
+        }
+
+        // then
+        assertThat(call("/api/projects", unauthorized).getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void doFilter_비활성화되면_제한하지않음() throws Exception {
+        // given
+        properties.setEnabled(false);
+        FilterChain unauthorized = (req, res) -> ((MockHttpServletResponse) res).setStatus(401);
+
+        // when
+        for (int i = 0; i < 10; i++) {
+            call("/api/admin/login", unauthorized);
+        }
+
+        // then
+        assertThat(call("/api/admin/login", unauthorized).getStatus()).isEqualTo(401);
+    }
+
+    private MockHttpServletResponse call(String path, FilterChain chain) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", path);
+        request.setRemoteAddr(CLIENT_IP);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, chain);
+        return response;
+    }
+
+    private RateLimitProperties.Limit limit(int capacity, Duration window) {
+        RateLimitProperties.Limit limit = new RateLimitProperties.Limit();
+        limit.setCapacity(capacity);
+        limit.setWindow(window);
+        return limit;
+    }
+}

--- a/src/test/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitServiceTest.java
+++ b/src/test/java/com/example/cowmjucraft/global/config/ratelimit/RateLimitServiceTest.java
@@ -1,0 +1,105 @@
+package com.example.cowmjucraft.global.config.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RateLimitServiceTest {
+
+    private RateLimitProperties properties;
+    private RateLimitService rateLimitService;
+
+    @BeforeEach
+    void setUp() {
+        properties = new RateLimitProperties();
+        properties.setRules(Map.of(
+                RateLimitRule.ADMIN_LOGIN.getKey(), limit(3, Duration.ofMinutes(10))
+        ));
+        rateLimitService = new RateLimitService(properties);
+    }
+
+    @Test
+    void hasCapacity_한도내소모_true반환() {
+        // given
+        rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+        rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+
+        // when & then
+        assertThat(rateLimitService.hasCapacity(RateLimitRule.ADMIN_LOGIN, "1.1.1.1")).isTrue();
+    }
+
+    @Test
+    void hasCapacity_한도소진_false반환() {
+        // given
+        for (int i = 0; i < 3; i++) {
+            rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+        }
+
+        // when & then
+        assertThat(rateLimitService.hasCapacity(RateLimitRule.ADMIN_LOGIN, "1.1.1.1")).isFalse();
+    }
+
+    @Test
+    void hasCapacity_클라이언트키가다르면_서로영향없음() {
+        // given
+        for (int i = 0; i < 3; i++) {
+            rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+        }
+
+        // when & then
+        assertThat(rateLimitService.hasCapacity(RateLimitRule.ADMIN_LOGIN, "1.1.1.1")).isFalse();
+        assertThat(rateLimitService.hasCapacity(RateLimitRule.ADMIN_LOGIN, "2.2.2.2")).isTrue();
+    }
+
+    @Test
+    void hasCapacity_설정없는규칙_제한하지않음() {
+        // given — ORDER_LOOKUP은 rules에 없다
+        for (int i = 0; i < 100; i++) {
+            rateLimitService.consume(RateLimitRule.ORDER_LOOKUP, "1.1.1.1");
+        }
+
+        // when & then
+        assertThat(rateLimitService.hasCapacity(RateLimitRule.ORDER_LOOKUP, "1.1.1.1")).isTrue();
+    }
+
+    @Test
+    void evictIdleBuckets_유휴시간이지나지않은버킷은유지() {
+        // given
+        properties.setIdleEviction(Duration.ofMinutes(30));
+        rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+        rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+        rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+
+        // when
+        rateLimitService.evictIdleBuckets();
+
+        // then — 카운터가 유지되어야 한다
+        assertThat(rateLimitService.hasCapacity(RateLimitRule.ADMIN_LOGIN, "1.1.1.1")).isFalse();
+    }
+
+    @Test
+    void evictIdleBuckets_유휴버킷제거후_카운터초기화() {
+        // given
+        rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+        rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+        rateLimitService.consume(RateLimitRule.ADMIN_LOGIN, "1.1.1.1");
+        assertThat(rateLimitService.hasCapacity(RateLimitRule.ADMIN_LOGIN, "1.1.1.1")).isFalse();
+
+        // when — 유휴 기준을 0으로 두어 즉시 제거 대상이 되게 한다
+        properties.setIdleEviction(Duration.ZERO);
+        rateLimitService.evictIdleBuckets();
+
+        // then
+        assertThat(rateLimitService.hasCapacity(RateLimitRule.ADMIN_LOGIN, "1.1.1.1")).isTrue();
+    }
+
+    private RateLimitProperties.Limit limit(int capacity, Duration window) {
+        RateLimitProperties.Limit limit = new RateLimitProperties.Limit();
+        limit.setCapacity(capacity);
+        limit.setWindow(window);
+        return limit;
+    }
+}

--- a/src/test/java/com/example/cowmjucraft/global/security/CredentialMatcherTest.java
+++ b/src/test/java/com/example/cowmjucraft/global/security/CredentialMatcherTest.java
@@ -1,0 +1,81 @@
+package com.example.cowmjucraft.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class CredentialMatcherTest {
+
+    private PasswordEncoder passwordEncoder;
+    private CredentialMatcher credentialMatcher;
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = new BCryptPasswordEncoder();
+        credentialMatcher = new CredentialMatcher(passwordEncoder);
+    }
+
+    @Test
+    void matches_비밀번호일치_true반환() {
+        // given
+        String storedHash = passwordEncoder.encode("Pa$$w0rd!");
+
+        // when & then
+        assertThat(credentialMatcher.matches("Pa$$w0rd!", storedHash)).isTrue();
+    }
+
+    @Test
+    void matches_비밀번호불일치_false반환() {
+        // given
+        String storedHash = passwordEncoder.encode("Pa$$w0rd!");
+
+        // when & then
+        assertThat(credentialMatcher.matches("wrong", storedHash)).isFalse();
+    }
+
+    @Test
+    void matches_저장된해시없음_false반환() {
+        // when & then
+        assertThat(credentialMatcher.matches("anything", null)).isFalse();
+    }
+
+    @Test
+    void matches_입력비밀번호가null_false반환() {
+        // given
+        String storedHash = passwordEncoder.encode("Pa$$w0rd!");
+
+        // when & then
+        assertThat(credentialMatcher.matches(null, storedHash)).isFalse();
+    }
+
+    @Test
+    void matches_대상없을때도_해시연산시간이유지된다() {
+        // given — 존재하는 계정의 실패 대조와 존재하지 않는 계정의 대조 시간을 비교한다
+        String storedHash = passwordEncoder.encode("Pa$$w0rd!");
+        warmUp(storedHash);
+
+        // when
+        long existingNanos = measure(() -> credentialMatcher.matches("wrong", storedHash));
+        long missingNanos = measure(() -> credentialMatcher.matches("wrong", null));
+
+        // then — 대상이 없을 때가 유의미하게 빠르면 타이밍으로 존재 여부가 새어나간다.
+        // bcrypt 연산 시간의 절반 이상은 소요되어야 한다.
+        assertThat(missingNanos).isGreaterThan(existingNanos / 2);
+    }
+
+    private void warmUp(String storedHash) {
+        for (int i = 0; i < 3; i++) {
+            credentialMatcher.matches("wrong", storedHash);
+            credentialMatcher.matches("wrong", null);
+        }
+    }
+
+    private long measure(Runnable runnable) {
+        long start = System.nanoTime();
+        runnable.run();
+        return System.nanoTime() - start;
+    }
+}

--- a/src/test/java/com/example/cowmjucraft/global/security/PasswordPolicyTest.java
+++ b/src/test/java/com/example/cowmjucraft/global/security/PasswordPolicyTest.java
@@ -1,0 +1,52 @@
+package com.example.cowmjucraft.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PasswordPolicyTest {
+
+    private final PasswordPolicy passwordPolicy = new PasswordPolicy();
+
+    @ParameterizedTest
+    @ValueSource(strings = {"abcd1234", "Pa55word!", "명지공방2026"})
+    void isValid_영문숫자8자이상_true반환(String rawPassword) {
+        assertThat(passwordPolicy.isValid(rawPassword)).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {
+            "1234",          // 너무 짧다
+            "abc123",        // 8자 미만
+            "abcdefgh",      // 숫자 없음
+            "12345678",      // 문자 없음
+            "        "       // 공백만
+    })
+    void isValid_정책미달_false반환(String rawPassword) {
+        assertThat(passwordPolicy.isValid(rawPassword)).isFalse();
+    }
+
+    @Test
+    void isValid_bcrypt한계인72바이트초과_false반환() {
+        // given — 한글 1자는 UTF-8에서 3바이트다
+        String tooLong = "가".repeat(24) + "a1";
+
+        // when & then
+        assertThat(tooLong.getBytes(java.nio.charset.StandardCharsets.UTF_8).length).isGreaterThan(72);
+        assertThat(passwordPolicy.isValid(tooLong)).isFalse();
+    }
+
+    @Test
+    void isValid_72바이트경계_true반환() {
+        // given — 영문 70자 + 숫자 2자 = 72바이트
+        String boundary = "a".repeat(70) + "12";
+
+        // when & then
+        assertThat(boundary.getBytes(java.nio.charset.StandardCharsets.UTF_8).length).isEqualTo(72);
+        assertThat(passwordPolicy.isValid(boundary)).isTrue();
+    }
+}


### PR DESCRIPTION
# 요약

로그인·주문 조회·지원서 조회 엔드포인트에 시도 횟수 제한이 없어 자동화된 반복 요청을 막을 수단이 없었습니다. 요청 제한을 중심으로, 그 전제가 되는 프록시 IP 인식과 함께 다루는 게 자연스러운 두 항목(응답 시간 균일화, 비밀번호 정책)을 묶었습니다.

커밋 4개로 나눴고 **각각 독립적으로 빌드·리뷰·revert 가능**합니다.

# 작업 내용

- [x] **`chore:` 리버스 프록시 뒤 클라이언트 IP 인식 설정** (`2197aa9`)
  - `server.forward-headers-strategy: framework`
  - ⚠️ **나머지 커밋의 전제입니다.** 이 설정 없이는 `getRemoteAddr()`가 프록시 IP만 반환해 모든 사용자가 한 IP로 묶입니다
  - `X-Forwarded-For` 유무에 따른 IP 해석을 통합 테스트로 검증

- [x] **`feat:` 인증·조회 엔드포인트 요청 제한** (`ad77653`)
  - Bucket4j 토큰 버킷 기반 필터, Security 필터 체인 앞에 등록
  - 임계값은 전부 환경변수로 조정 가능, `RATE_LIMIT_ENABLED=false`로 즉시 비활성화 가능
  - 유휴 버킷 주기적 정리

- [x] **`refactor:` 자격증명 대조 응답 시간 균일화** (`5ec80d5`)
  - 대상이 없을 때도 더미 해시로 같은 연산 수행
  - 적용: 관리자 로그인, 주문 조회, 지원서 조회·수정·결과 조회

- [x] **`feat:` 비회원 조회 비밀번호 최소 강도 검증** (`28aad13`)
  - 8자 이상 + 영문·숫자 포함, bcrypt 한계인 72바이트 상한
  - 주문·지원서가 같은 정책(`PasswordPolicy`)을 공유

**테스트**: 51개 전부 통과 (기존 20 + 신규 31). 커밋별 독립 빌드도 확인했습니다.

# 기타 (논의하고 싶은 부분)

**1. 왜 "실패한 요청만" 세는가**

캠퍼스 와이파이나 캐리어 NAT에서는 여러 사용자가 같은 IP로 보입니다. 전체 요청을 세면 정상 사용자끼리 한도를 잠식합니다.

| | 전체 카운트 | 실패만 카운트 |
|---|---|---|
| 정상 사용자 10명이 각자 1번씩 성공 | 10회 소진 | **0회 소진** |
| 반복 시도 100번 | 100회 | 100회 |

401·404만 세고 400·422(입력 형식 오류)는 세지 않습니다.

조회 아이디 중복 확인만 예외로 성공 응답까지 셉니다 — 응답 자체가 해당 ID의 존재 여부를 알려주기 때문입니다.

**2. 임계값 초안** (조정 의견 환영)

| 엔드포인트 | 카운트 | 제한 |
|---|---|---|
| `/api/admin/login` | 실패만 | 10회/10분 |
| `/api/admin/refresh` | 실패만 | 20회/분 |
| `/api/orders/lookup` | 실패만 | 10회/10분 |
| `/api/application/read`, `/api/result` | 실패만 | 10회/10분 |
| `/api/orders/lookup-id/availability` | 전체 | 20회/분 |

**3. 알려진 제약**

- **단일 인스턴스 전제**입니다. 인메모리라 스케일아웃하면 인스턴스별로 카운터가 갈립니다. 현재 Coolify 단일 컨테이너 배포라 문제없지만, 확장 시 Redis 기반으로 교체해야 합니다
- **계정 단위 제한은 제외**했습니다. 요청 본문에서 로그인 ID를 읽으려면 `ContentCachingRequestWrapper`가 필요해 복잡도가 올라갑니다. 분산 공격(여러 IP → 한 계정) 방어용인데 현재 규모에선 과하다고 판단했습니다

# 타 직군 전달 사항

**프런트 영향 2건입니다.**

1. **`PUT /api/application` 응답 코드 변경** — 지원서가 없을 때 `404 APPLICATION_NOT_FOUND` → `401 INVALID_CREDENTIALS`. 존재 여부를 숨기려면 두 경우의 응답이 같아야 합니다. 현재 프런트는 응답 메시지만 사용해 구조적 영향은 없습니다.

2. **비밀번호 정책이 신규 주문·지원서에 적용됩니다** — 8자 미만이거나 영문·숫자가 섞이지 않으면 422입니다. 기존 데이터의 조회는 영향받지 않습니다. 입력 폼에 안내 문구를 추가해주시면 좋겠습니다.

**429 응답 처리**도 확인 부탁드립니다. `Retry-After` 헤더에 재시도 대기 시간(초)이 담깁니다.