### PR TITLE
fix: 리프레시 토큰 단일 소비 보장 및 재사용 탐지 추가

### DIFF
--- a/src/main/java/com/example/cowmjucraft/domain/accounts/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/cowmjucraft/domain/accounts/auth/repository/RefreshTokenRepository.java
@@ -14,6 +14,29 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByTokenHash(String tokenHash);
 
+    /**
+     * 미폐기 상태일 때만 폐기해 토큰을 원자적으로 소비한다.
+     *
+     * <p>조회 후 검사하고 변경하는 방식은 동시 요청 둘이 모두 미폐기 상태를 읽어
+     * 각각 새 토큰 쌍을 발급받을 수 있다. 조건을 UPDATE 문에 넣어 DB가 한 번만
+     * 성공하도록 보장한다.
+     *
+     * @return 1이면 이번 호출이 소비에 성공한 것, 0이면 이미 소비됐거나 존재하지 않는다
+     */
+    // clearAutomatically는 쓰지 않는다 — 벌크 대상뿐 아니라 persistence context 전체를
+    // detach시켜 이후 dirty checking이 동작하지 않는다.
+    @Modifying(flushAutomatically = true)
+    @Query("""
+            update RefreshToken t
+               set t.revokedAt = :now
+             where t.tokenHash = :tokenHash
+               and t.revokedAt is null
+            """)
+    int consumeIfActive(
+            @Param("tokenHash") String tokenHash,
+            @Param("now") LocalDateTime now
+    );
+
     @Modifying
     @Query("""
             update RefreshToken t

--- a/src/main/java/com/example/cowmjucraft/domain/accounts/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/cowmjucraft/domain/accounts/auth/service/RefreshTokenService.java
@@ -7,6 +7,7 @@ import com.example.cowmjucraft.domain.accounts.exception.AccountErrorType;
 import com.example.cowmjucraft.domain.accounts.exception.AccountException;
 import com.example.cowmjucraft.global.config.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 import java.util.HexFormat;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
@@ -59,19 +61,52 @@ public class RefreshTokenService {
         }
 
         String subject = jwtTokenProvider.getSubject(rawRefreshToken);
-        RefreshToken savedRefreshToken = refreshTokenRepository.findByTokenHash(hashToken(rawRefreshToken))
+        String tokenHash = hashToken(rawRefreshToken);
+        LocalDateTime now = LocalDateTime.now();
+
+        // 조회-검사-변경이 아니라 조건부 UPDATE로 소비한다. 동시 요청이 들어와도
+        // DB가 한 번만 성공시키므로 하나의 토큰에서 두 세션이 파생되지 않는다.
+        if (refreshTokenRepository.consumeIfActive(tokenHash, now) == 0) {
+            handleUnusableToken(tokenHash, subject);
+        }
+
+        RefreshToken consumed = refreshTokenRepository.findByTokenHash(tokenHash)
                 .orElseThrow(() -> new AccountException(AccountErrorType.INVALID_REFRESH_TOKEN));
 
-        LocalDateTime now = LocalDateTime.now();
-        if (savedRefreshToken.getRevokedAt() != null) {
-            throw new AccountException(AccountErrorType.INVALID_REFRESH_TOKEN);
-        }
-        if (!savedRefreshToken.getExpiresAt().isAfter(now)) {
+        // 만료 토큰은 이미 폐기된 상태로 남는다 — 재사용 여지를 없애는 편이 안전하다.
+        if (!consumed.getExpiresAt().isAfter(now)) {
             throw new AccountException(AccountErrorType.REFRESH_TOKEN_EXPIRED);
         }
 
-        savedRefreshToken.revoke(now);
         return issueTokenPair(subject, expectedRole);
+    }
+
+    /**
+     * 소비에 실패한 토큰을 분류한다.
+     *
+     * <p>이미 폐기된 토큰이 다시 등장하는 것은 회전형 방식에서 탈취를 의심할 근거다.
+     * 정상 사용자는 폐기된 토큰을 다시 쓸 일이 없다. 해당 주체의 활성 토큰을 모두
+     * 무효화해 공격자와 정상 사용자 양쪽의 세션을 끊는다.
+     */
+    private void handleUnusableToken(String tokenHash, String subject) {
+        RefreshToken existing = refreshTokenRepository.findByTokenHash(tokenHash).orElse(null);
+
+        if (existing == null) {
+            throw new AccountException(AccountErrorType.INVALID_REFRESH_TOKEN);
+        }
+
+        log.warn(
+                "폐기된 리프레시 토큰 재사용 감지 — 해당 주체의 활성 토큰을 모두 폐기합니다. subject={}, role={}",
+                subject,
+                existing.getRole()
+        );
+        refreshTokenRepository.revokeActiveTokens(
+                existing.getSubject(),
+                existing.getRole(),
+                LocalDateTime.now()
+        );
+
+        throw new AccountException(AccountErrorType.INVALID_REFRESH_TOKEN);
     }
 
     @Transactional

--- a/src/test/java/com/example/cowmjucraft/domain/accounts/auth/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/example/cowmjucraft/domain/accounts/auth/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,98 @@
+package com.example.cowmjucraft.domain.accounts.auth.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.cowmjucraft.domain.accounts.Role;
+import com.example.cowmjucraft.domain.accounts.auth.entity.RefreshToken;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+/**
+ * 리프레시 토큰의 원자적 소비 쿼리를 검증한다.
+ * 단일 소비 보장이 이 쿼리 하나에 달려 있어 실제 DB에서 확인한다.
+ */
+@DataJpaTest
+class RefreshTokenRepositoryTest {
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void consumeIfActive_활성토큰_1반환하고폐기된다() {
+        // given
+        RefreshToken token = save("hash-active", LocalDateTime.now().plusDays(7));
+        flushAndClear();
+
+        // when
+        int affected = refreshTokenRepository.consumeIfActive("hash-active", LocalDateTime.now());
+        flushAndClear();
+
+        // then
+        assertThat(affected).isEqualTo(1);
+        assertThat(refreshTokenRepository.findById(token.getId()))
+                .get()
+                .extracting(RefreshToken::getRevokedAt)
+                .isNotNull();
+    }
+
+    @Test
+    void consumeIfActive_두번연속호출_두번째는0반환() {
+        // given
+        save("hash-once", LocalDateTime.now().plusDays(7));
+        flushAndClear();
+
+        // when — 동시 요청이 순차적으로 도달한 상황과 동일하다
+        int first = refreshTokenRepository.consumeIfActive("hash-once", LocalDateTime.now());
+        flushAndClear();
+        int second = refreshTokenRepository.consumeIfActive("hash-once", LocalDateTime.now());
+        flushAndClear();
+
+        // then — 정확히 한 번만 성공해야 한다
+        assertThat(first).isEqualTo(1);
+        assertThat(second).isZero();
+    }
+
+    @Test
+    void consumeIfActive_존재하지않는해시_0반환() {
+        // when
+        int affected = refreshTokenRepository.consumeIfActive("no-such-hash", LocalDateTime.now());
+
+        // then
+        assertThat(affected).isZero();
+    }
+
+    @Test
+    void consumeIfActive_다른토큰에는영향없다() {
+        // given
+        save("hash-a", LocalDateTime.now().plusDays(7));
+        RefreshToken other = save("hash-b", LocalDateTime.now().plusDays(7));
+        flushAndClear();
+
+        // when
+        refreshTokenRepository.consumeIfActive("hash-a", LocalDateTime.now());
+        flushAndClear();
+
+        // then
+        assertThat(refreshTokenRepository.findById(other.getId()))
+                .get()
+                .extracting(RefreshToken::getRevokedAt)
+                .isNull();
+    }
+
+    private RefreshToken save(String tokenHash, LocalDateTime expiresAt) {
+        return refreshTokenRepository.save(
+                new RefreshToken("admin", Role.ROLE_ADMIN, tokenHash, expiresAt)
+        );
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/com/example/cowmjucraft/domain/accounts/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/example/cowmjucraft/domain/accounts/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,153 @@
+package com.example.cowmjucraft.domain.accounts.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.cowmjucraft.domain.accounts.Role;
+import com.example.cowmjucraft.domain.accounts.auth.entity.RefreshToken;
+import com.example.cowmjucraft.domain.accounts.auth.repository.RefreshTokenRepository;
+import com.example.cowmjucraft.domain.accounts.exception.AccountErrorType;
+import com.example.cowmjucraft.domain.accounts.exception.AccountException;
+import com.example.cowmjucraft.global.config.jwt.JwtTokenProvider;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RefreshTokenServiceTest {
+
+    private static final String RAW_TOKEN = "raw-refresh-token";
+    private static final String SUBJECT = "admin";
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void setUp() {
+        when(jwtTokenProvider.validateRefreshToken(RAW_TOKEN)).thenReturn(true);
+        when(jwtTokenProvider.getRole(RAW_TOKEN)).thenReturn(Role.ROLE_ADMIN.name());
+        when(jwtTokenProvider.getSubject(RAW_TOKEN)).thenReturn(SUBJECT);
+        when(jwtTokenProvider.generateAccessToken(anyString(), any())).thenReturn("new-access");
+        when(jwtTokenProvider.generateRefreshToken(anyString(), any())).thenReturn("new-refresh");
+        when(jwtTokenProvider.getAccessExpirationSeconds()).thenReturn(900L);
+        when(jwtTokenProvider.getRefreshExpirationSeconds()).thenReturn(1_209_600L);
+    }
+
+    @Test
+    void refresh_유효한토큰_소비후새토큰쌍발급() {
+        // given
+        when(refreshTokenRepository.consumeIfActive(anyString(), any())).thenReturn(1);
+        when(refreshTokenRepository.findByTokenHash(anyString()))
+                .thenReturn(Optional.of(activeToken(LocalDateTime.now().plusDays(7))));
+
+        // when
+        RefreshTokenService.TokenPair pair = refreshTokenService.refresh(RAW_TOKEN, Role.ROLE_ADMIN);
+
+        // then
+        assertThat(pair.accessToken()).isEqualTo("new-access");
+        assertThat(pair.refreshToken()).isEqualTo("new-refresh");
+        verify(refreshTokenRepository).consumeIfActive(anyString(), any());
+        verify(refreshTokenRepository, never()).revokeActiveTokens(anyString(), any(), any());
+    }
+
+    @Test
+    void refresh_이미소비된토큰_재사용으로보고전체세션폐기() {
+        // given — 조건부 UPDATE가 0을 반환하고, 조회하면 폐기된 토큰이 존재한다
+        when(refreshTokenRepository.consumeIfActive(anyString(), any())).thenReturn(0);
+        RefreshToken revoked = activeToken(LocalDateTime.now().plusDays(7));
+        revoked.revoke(LocalDateTime.now().minusMinutes(1));
+        when(refreshTokenRepository.findByTokenHash(anyString())).thenReturn(Optional.of(revoked));
+
+        // when & then
+        assertThatThrownBy(() -> refreshTokenService.refresh(RAW_TOKEN, Role.ROLE_ADMIN))
+                .isInstanceOf(AccountException.class)
+                .extracting(e -> ((AccountException) e).getErrorCode())
+                .isEqualTo(AccountErrorType.INVALID_REFRESH_TOKEN);
+
+        // 탈취 신호로 보고 해당 주체의 활성 토큰을 모두 폐기해야 한다
+        verify(refreshTokenRepository).revokeActiveTokens(eq(SUBJECT), eq(Role.ROLE_ADMIN), any());
+    }
+
+    @Test
+    void refresh_존재하지않는토큰_전체폐기없이예외() {
+        // given
+        when(refreshTokenRepository.consumeIfActive(anyString(), any())).thenReturn(0);
+        when(refreshTokenRepository.findByTokenHash(anyString())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> refreshTokenService.refresh(RAW_TOKEN, Role.ROLE_ADMIN))
+                .isInstanceOf(AccountException.class);
+
+        // 없는 토큰은 탈취 신호가 아니므로 다른 세션을 끊으면 안 된다
+        verify(refreshTokenRepository, never()).revokeActiveTokens(anyString(), any(), any());
+    }
+
+    @Test
+    void refresh_만료된토큰_REFRESH_TOKEN_EXPIRED발생() {
+        // given
+        when(refreshTokenRepository.consumeIfActive(anyString(), any())).thenReturn(1);
+        when(refreshTokenRepository.findByTokenHash(anyString()))
+                .thenReturn(Optional.of(activeToken(LocalDateTime.now().minusSeconds(1))));
+
+        // when & then
+        assertThatThrownBy(() -> refreshTokenService.refresh(RAW_TOKEN, Role.ROLE_ADMIN))
+                .isInstanceOf(AccountException.class)
+                .extracting(e -> ((AccountException) e).getErrorCode())
+                .isEqualTo(AccountErrorType.REFRESH_TOKEN_EXPIRED);
+    }
+
+    @Test
+    void refresh_역할이다른토큰_소비시도없이예외() {
+        // given
+        when(jwtTokenProvider.getRole(RAW_TOKEN)).thenReturn("ROLE_USER");
+
+        // when & then
+        assertThatThrownBy(() -> refreshTokenService.refresh(RAW_TOKEN, Role.ROLE_ADMIN))
+                .isInstanceOf(AccountException.class);
+
+        verify(refreshTokenRepository, never()).consumeIfActive(anyString(), any());
+    }
+
+    @Test
+    void refresh_서명이유효하지않은토큰_소비시도없이예외() {
+        // given
+        when(jwtTokenProvider.validateRefreshToken(RAW_TOKEN)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> refreshTokenService.refresh(RAW_TOKEN, Role.ROLE_ADMIN))
+                .isInstanceOf(AccountException.class);
+
+        verify(refreshTokenRepository, never()).consumeIfActive(anyString(), any());
+    }
+
+    @Test
+    void refresh_토큰이비어있으면_예외() {
+        assertThatThrownBy(() -> refreshTokenService.refresh("  ", Role.ROLE_ADMIN))
+                .isInstanceOf(AccountException.class);
+        assertThatThrownBy(() -> refreshTokenService.refresh(null, Role.ROLE_ADMIN))
+                .isInstanceOf(AccountException.class);
+    }
+
+    private RefreshToken activeToken(LocalDateTime expiresAt) {
+        return new RefreshToken(SUBJECT, Role.ROLE_ADMIN, "hash", expiresAt);
+    }
+}


### PR DESCRIPTION
# 요약

리프레시 토큰의 소비를 원자적으로 처리하고, 이미 폐기된 토큰이 다시 사용되는 상황을 감지해 해당 주체의 세션을 정리합니다.

# 작업 내용

- [x] `RefreshTokenRepository.consumeIfActive()` 추가 — 조건부 UPDATE로 원자적 소비
- [x] `RefreshTokenService.refresh()`가 조회-검사-변경 대신 조건부 UPDATE 사용
- [x] 폐기된 토큰 재사용 감지 시 해당 주체의 활성 토큰 일괄 폐기 + 경고 로그
- [x] 만료 검사를 소비 이후로 이동 (만료 토큰도 폐기 상태로 남김)
- [x] 서비스 단위 테스트 7건
- [x] 리포지토리 슬라이스 테스트 4건

# 기술적 변경 포인트

**조건부 UPDATE로 소비**

```sql
update RefreshToken t set t.revokedAt = :now
 where t.tokenHash = :tokenHash and t.revokedAt is null
```

기존에는 토큰을 조회해 `revokedAt`을 확인한 뒤 변경했습니다. 같은 토큰으로 동시 요청이 들어오면 둘 다 미폐기 상태를 읽어 각각 새 토큰 쌍을 발급받을 수 있었습니다. 조건을 UPDATE 문에 넣어 DB가 한 번만 성공시키게 했습니다.

반환값이 `1`이면 이번 호출이 소비에 성공한 것, `0`이면 이미 소비됐거나 존재하지 않는 토큰입니다.

**`clearAutomatically`를 쓰지 않았습니다**

`@Modifying(flushAutomatically = true)`만 적용했습니다. `clearAutomatically`는 벌크 대상뿐 아니라 persistence context 전체를 detach시켜 이후 dirty checking이 동작하지 않게 됩니다 (#139에서 지적된 문제와 동일). 코드에도 주석으로 남겼습니다.

**소비 실패 원인 분류**

| 상황 | 처리 |
|---|---|
| 토큰이 존재하지 않음 | 401 반환. 다른 세션은 건드리지 않음 |
| 폐기된 토큰이 재등장 | 해당 주체의 활성 토큰 전체 폐기 + 경고 로그 → 401 |

정상 사용자는 폐기된 토큰을 다시 쓸 일이 없습니다. 존재하지 않는 토큰까지 같은 취급을 하면 무관한 사용자의 세션을 끊을 수 있어 구분했습니다.

경고 로그에는 `subject`와 `role`만 남기고 **토큰 원문·해시는 기록하지 않습니다.**

**만료 검사 시점**

소비 이후에 수행합니다. 만료된 토큰도 폐기 상태로 남겨 재사용 여지를 없앴습니다.

# 테스트 방법

`./gradlew test` — 31개 전부 통과 (기존 20 + 신규 11)

**리포지토리 슬라이스 테스트를 추가한 이유**

이 수정의 핵심이 JPQL 한 줄이라 mock 기반 단위 테스트로는 검증되지 않습니다. `@DataJpaTest`로 실제 DB 동작을 확인했고, 특히 **두 번 연속 호출 시 첫 번째만 `1`을 반환**하는 것을 고정했습니다.

> 참고: Boot 4에서 `@DataJpaTest` 패키지가 `org.springframework.boot.data.jpa.test.autoconfigure`로 변경되었습니다. 이 레포 최초의 리포지토리 슬라이스 테스트라 #142 진행 시 참고 사례로 쓸 수 있습니다.

# 배포 영향

없습니다. 스키마 변경, 환경 변수 추가 모두 없습니다.

# 기타 (논의하고 싶은 부분)

**⚠️ 머지 순서**

프런트엔드에서 토큰 재발급 흐름을 구현하는 PR(COW-MJCRAFT-FE#205)이 열려 있습니다. **이 PR이 먼저 배포된 뒤 FE PR을 머지**해주세요. 현재 프런트는 재발급을 사용하지 않아 이 경로가 거의 쓰이지 않지만, FE가 사용을 시작하면 동시 요청 처리가 실제로 중요해집니다.

**후속 예정**

FE 재발급 흐름이 안정화되면 액세스 토큰 수명을 1시간에서 15분 수준으로 줄일 예정입니다.

# 타 직군 전달 사항

API 계약 변경은 없습니다. `/api/admin/refresh`의 요청·응답 형식은 그대로입니다.